### PR TITLE
Macro Refactor

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -16,8 +16,8 @@ typedef size_t usize;
 typedef float f32;
 typedef double f64;
 
-#define MAX(a,b) (((a)>(b))?(a):(b))
-#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MAX(mA,mB) (((mA)>(mB))?(mA):(mB))
+#define MIN(mA,mB) (((mA)<(mB))?(mA):(mB))
 
 #define VECTOR2_ZERO (Vector2) { .x = 0, .y = 0 }
 

--- a/src/systems.c
+++ b/src/systems.c
@@ -5,8 +5,8 @@
 #include "systems.h"
 #include <assert.h>
 
-#define REQUIRE_DEPS(dependencies) if ((scene->components.tags[entity] & (dependencies)) != (dependencies)) return
-#define ENTITY_HAS_DEPS(other, dependencies) ((scene->components.tags[other] & (dependencies)) == (dependencies))
+#define REQUIRE_DEPS(mDependencies) if ((scene->components.tags[entity] & (mDependencies)) != (mDependencies)) return
+#define ENTITY_HAS_DEPS(mEntity, mDependencies) ((scene->components.tags[mEntity] & (mDependencies)) == (mDependencies))
 
 typedef struct
 {


### PR DESCRIPTION
`REQUIRE_DEPS` and `ENTITY_HAS_DEPS` now depend on `scene`, not `components`; we no longer have to remember to define `Components*` at the top of a system. 

 Also, from now on macros should prefix their parameters with an `m`!