### PR TITLE
Address potentially invalid `RenderTexture2D` dimensions

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -5,6 +5,9 @@
 #define CTX_VIEWPORT_WIDTH 320
 #define CTX_VIEWPORT_HEIGHT 180
 
+#define DEFAULT_WINDOW_WIDTH CTX_VIEWPORT_WIDTH * 3
+#define DEFAULT_WINDOW_HEIGHT CTX_VIEWPORT_HEIGHT * 3
+
 // Target (fixed) delta time.
 #define CTX_DT (1.0 / 60.0)
 

--- a/src/game.c
+++ b/src/game.c
@@ -57,9 +57,7 @@ static void Timestep(void)
 int main(void)
 {
     // TODO(thismarvin): Incorporate a config file or cli options for window resolution.
-    const f32 scale = 3;
-
-    InitWindow(CTX_VIEWPORT_WIDTH * scale, CTX_VIEWPORT_HEIGHT * scale, "LTL");
+    InitWindow(DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT, "LTL");
     InitAudioDevice();
 
     SetWindowState(FLAG_VSYNC_HINT | FLAG_WINDOW_RESIZABLE);

--- a/src/scene.c
+++ b/src/scene.c
@@ -256,12 +256,25 @@ static void SceneSetupTargetTexture(Scene* self)
     };
 
     // TODO(thismarvin): Expose a "Render Resolution" option.
+
+    // Use the monitor's resolution as the default render resolution.
+    const int currentMonitor = GetCurrentMonitor();
+    int width = GetMonitorWidth(currentMonitor);
+    int height = GetMonitorHeight(currentMonitor);
+
+    // The following is always true for every platform except desktop.
+    if (width == 0 || height == 0)
+    {
+        width = DEFAULT_WINDOW_WIDTH;
+        height = DEFAULT_WINDOW_HEIGHT;
+    }
+
     Rectangle renderResolution = (Rectangle)
     {
         .x = 0,
         .y = 0,
-        .width = GetMonitorWidth(GetCurrentMonitor()),
-        .height = GetMonitorHeight(GetCurrentMonitor()),
+        .width = width,
+        .height = height,
     };
 
     f32 zoom = CalculateZoom(self->trueResolution, renderResolution);


### PR DESCRIPTION
With these changes, `PLATFORM_WEB` now works!

Previously, `Scene`'s `targetTexture`'s width and height were set to zero; `GetMonitorWidth` and `GetMonitorHeight` return zero on every platform except desktop. In order to fix this, I simply made it so every platform except desktop defaults to using the window's initial dimensions.