### PR TITLE
Collision Rework (Avoiding Side Effects)

### DIFF
--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -39,8 +39,6 @@ typedef void (*OnDamage)(const OnDamageParams*);
 typedef struct
 {
     Rectangle aabb;
-    // Whether or not the current collision axis pass should stop.
-    bool stop;
 } OnCollisionResult;
 
 typedef struct

--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -38,11 +38,10 @@ typedef void (*OnDamage)(const OnDamageParams*);
 
 typedef struct
 {
-    bool xAxisResolved;
-    bool yAxisResolved;
+    Rectangle aabb;
+    // Whether or not the current collision axis pass should stop.
+    bool stop;
 } OnCollisionResult;
-
-#define ON_COLLISION_RESULT_NONE (OnCollisionResult) { false, false }
 
 typedef struct
 {

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -7,23 +7,28 @@ static OnCollisionResult CloudParticleOnCollision(const OnCollisionParams* param
 {
     assert(ENTITY_HAS_DEPS(params->entity, TAG_POSITION));
 
-    CPosition* position = GET_COMPONENT(position, params->entity);
+    const CPosition* position = GET_COMPONENT(position, params->entity);
 
     // If the aabb is completely within another collider then remove it.
     if (params->overlap.width >= params->aabb.width && params->overlap.height >= params->aabb.height)
     {
         SceneDeferDeallocateEntity(params->scene, params->entity);
 
-        return ON_COLLISION_RESULT_NONE;
+        return (OnCollisionResult)
+        {
+            .aabb = params->aabb,
+            .stop = true,
+        };
     }
 
     // Resolve collision.
-    ApplyResolutionPerfectly(position, params->aabb, params->otherAabb, params->resolution);
+    Rectangle resolvedAabb = ApplyResolutionPerfectly(params->aabb, params->otherAabb,
+                             params->resolution);
 
     return (OnCollisionResult)
     {
-        .xAxisResolved = params->resolution.x != 0,
-        .yAxisResolved = params->resolution.y != 0,
+        .aabb = resolvedAabb,
+        .stop = true,
     };
 }
 

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -17,7 +17,6 @@ static OnCollisionResult CloudParticleOnCollision(const OnCollisionParams* param
         return (OnCollisionResult)
         {
             .aabb = params->aabb,
-            .stop = true,
         };
     }
 
@@ -28,7 +27,6 @@ static OnCollisionResult CloudParticleOnCollision(const OnCollisionParams* param
     return (OnCollisionResult)
     {
         .aabb = resolvedAabb,
-        .stop = true,
     };
 }
 

--- a/src/ecs/entities/common.c
+++ b/src/ecs/entities/common.c
@@ -1,29 +1,32 @@
 #include "common.h"
 
-void ApplyResolutionPerfectly
+Rectangle ApplyResolutionPerfectly
 (
-    CPosition* position,
     const Rectangle aabb,
     const Rectangle otherAabb,
     const Vector2 resolution
 )
 {
+    Rectangle result = aabb;
+
     if (resolution.x < 0)
     {
-        position->value.x = RectangleLeft(otherAabb) - aabb.width;
+        result.x = RectangleLeft(otherAabb) - aabb.width;
     }
     else if (resolution.x > 0)
     {
-        position->value.x = RectangleRight(otherAabb);
+        result.x = RectangleRight(otherAabb);
     }
 
     if (resolution.y < 0)
     {
-        position->value.y = RectangleTop(otherAabb) - aabb.height;
+        result.y = RectangleTop(otherAabb) - aabb.height;
     }
     else if (resolution.y > 0)
     {
-        position->value.y = RectangleBottom(otherAabb);
+        result.y = RectangleBottom(otherAabb);
     }
+
+    return result;
 }
 

--- a/src/ecs/entities/common.h
+++ b/src/ecs/entities/common.h
@@ -10,9 +10,8 @@
 #define ENTITY_HAS_DEPS(mEntity, mDependencies) ((params->scene->components.tags[mEntity] & (mDependencies)) == (mDependencies))
 #define GET_COMPONENT(mValue, mEntity) SCENE_GET_COMPONENT_PTR(params->scene, mValue, mEntity)
 
-void ApplyResolutionPerfectly
+Rectangle ApplyResolutionPerfectly
 (
-    CPosition* position,
     Rectangle aabb,
     Rectangle otherAabb,
     Vector2 resolution

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -52,7 +52,6 @@ static OnCollisionResult PlayerOnCollision(const OnCollisionParams* params)
             return (OnCollisionResult)
             {
                 .aabb = params->aabb,
-                .stop = false,
             };
         }
     }
@@ -76,7 +75,6 @@ static OnCollisionResult PlayerOnCollision(const OnCollisionParams* params)
             return (OnCollisionResult)
             {
                 .aabb = resolvedAabb,
-                .stop = false,
             };
         }
     }
@@ -108,7 +106,6 @@ static OnCollisionResult PlayerOnCollision(const OnCollisionParams* params)
     return (OnCollisionResult)
     {
         .aabb = resolvedAabb,
-        .stop = true,
     };
 }
 

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -28,7 +28,6 @@ static OnCollisionResult WalkerOnCollision(const OnCollisionParams* params)
     return (OnCollisionResult)
     {
         .aabb = resolvedAabb,
-        .stop = true,
     };
 }
 

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -5,11 +5,12 @@ static OnCollisionResult WalkerOnCollision(const OnCollisionParams* params)
 {
     assert(ENTITY_HAS_DEPS(params->entity, TAG_POSITION | TAG_KINETIC));
 
-    CPosition* position = GET_COMPONENT(position, params->entity);
+    const CPosition* position = GET_COMPONENT(position, params->entity);
     CKinetic* kinetic = GET_COMPONENT(kinetic, params->entity);
 
     // Resolve collision.
-    ApplyResolutionPerfectly(position, params->aabb, params->otherAabb, params->resolution);
+    Rectangle resolvedAabb = ApplyResolutionPerfectly(params->aabb, params->otherAabb,
+                             params->resolution);
 
     // Walk side to side.
     {
@@ -26,8 +27,8 @@ static OnCollisionResult WalkerOnCollision(const OnCollisionParams* params)
 
     return (OnCollisionResult)
     {
-        .xAxisResolved = params->resolution.x != 0,
-        .yAxisResolved = params->resolution.y != 0,
+        .aabb = resolvedAabb,
+        .stop = true,
     };
 }
 


### PR DESCRIPTION
At its core, the following changes simply make it so collision does not modify CPosition until the very end (of SCollisionUpdate).