### PR TITLE
Precise Collision

### DIFF
--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -43,6 +43,11 @@ typedef struct
 
 typedef struct
 {
+    Rectangle aabb;
+} OnResolutionResult;
+
+typedef struct
+{
     Scene* scene;
     usize entity;
     Rectangle aabb;
@@ -50,9 +55,21 @@ typedef struct
     Rectangle otherAabb;
     Rectangle overlap;
     Vector2 resolution;
+} OnResolutionParams;
+
+typedef OnResolutionResult (*OnResolution)(const OnResolutionParams*);
+
+typedef struct
+{
+    Scene* scene;
+    usize entity;
+    Rectangle aabb;
+    usize otherEntity;
+    Rectangle otherAabb;
+    Rectangle overlap;
 } OnCollisionParams;
 
-typedef OnCollisionResult (*OnCollision)(const OnCollisionParams*);
+typedef void (*OnCollision)(const OnCollisionParams*);
 
 typedef struct
 {
@@ -93,6 +110,7 @@ typedef struct
     u64 layer;
     // Layers you collide with.
     u64 mask;
+    OnResolution onResolution;
     OnCollision onCollision;
 } CCollider;
 

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -3,7 +3,7 @@
 #include <raymath.h>
 
 // TODO(thismarvin): The collider no longer scales...
-static OnCollisionResult CloudParticleOnCollision(const OnCollisionParams* params)
+static OnResolutionResult CloudParticleOnResolution(const OnResolutionParams* params)
 {
     assert(ENTITY_HAS_DEPS(params->entity, TAG_POSITION));
 
@@ -14,7 +14,7 @@ static OnCollisionResult CloudParticleOnCollision(const OnCollisionParams* param
     {
         SceneDeferDeallocateEntity(params->scene, params->entity);
 
-        return (OnCollisionResult)
+        return (OnResolutionResult)
         {
             .aabb = params->aabb,
         };
@@ -24,11 +24,13 @@ static OnCollisionResult CloudParticleOnCollision(const OnCollisionParams* param
     Rectangle resolvedAabb = ApplyResolutionPerfectly(params->aabb, params->otherAabb,
                              params->resolution);
 
-    return (OnCollisionResult)
+    return (OnResolutionResult)
     {
         .aabb = resolvedAabb,
     };
 }
+
+static void CloudParticleOnCollision() {}
 
 EntityBuilder CloudParticleCreate
 (
@@ -95,6 +97,7 @@ EntityBuilder CloudParticleCreate
     {
         .layer = LAYER_NONE,
         .mask = LAYER_ALL,
+        .onResolution = CloudParticleOnResolution,
         .onCollision = CloudParticleOnCollision,
     }));
 

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -1,7 +1,7 @@
 #include "common.h"
 #include "walker.h"
 
-static OnCollisionResult WalkerOnCollision(const OnCollisionParams* params)
+static OnResolutionResult WalkerOnResolution(const OnResolutionParams* params)
 {
     assert(ENTITY_HAS_DEPS(params->entity, TAG_POSITION | TAG_KINETIC));
 
@@ -25,11 +25,13 @@ static OnCollisionResult WalkerOnCollision(const OnCollisionParams* params)
         }
     }
 
-    return (OnCollisionResult)
+    return (OnResolutionResult)
     {
         .aabb = resolvedAabb,
     };
 }
+
+static void WalkerOnCollision() {}
 
 EntityBuilder WalkerCreate(const f32 x, const f32 y)
 {
@@ -86,6 +88,7 @@ EntityBuilder WalkerCreate(const f32 x, const f32 y)
     {
         .layer = LAYER_ALL,
         .mask = LAYER_ALL,
+        .onResolution = WalkerOnResolution,
         .onCollision = WalkerOnCollision,
     }));
 


### PR DESCRIPTION
The following changes will improve our collision resolution (at the cost of some performance). 

During our "Axis by Axis; Pixel by Pixel" process, every step through the given delta will iterate through **every** single collider in the scene. There is also now a distinction between `OnResolution` and `OnCollision` (the latter being invoked after resolution logic has completed).