### PR TITLE
Collision Layers (Redux)

### DIFF
--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -23,6 +23,10 @@
 #define RESOLVE_LEFT ((u8)1 << 3)
 #define RESOLVE_ALL (RESOLVE_UP | RESOLVE_RIGHT | RESOLVE_DOWN | RESOLVE_LEFT)
 
+#define LAYER_NONE ((u64)0)
+#define LAYER_TERRAIN ((u64)1 << 0)
+#define LAYER_LETHAL ((u64)1 << 1)
+
 // TODO(thismarvin): Naming components is hard...
 
 typedef struct Scene Scene;
@@ -108,6 +112,8 @@ typedef struct
 {
     // The directions other entities will resolve against.
     u8 resolutionSchema;
+    // Layer you exist on.
+    u64 layer;
     // Layers you collide with.
     u64 mask;
     OnResolution onResolution;

--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -16,12 +16,12 @@
 #define TAG_DAMAGE ((u64)1 << 10)
 #define TAG_FLEETING ((u64)1 << 11)
 
-#define LAYER_NONE ((u64)0)
-#define LAYER_UP ((u64)1 << 0)
-#define LAYER_RIGHT ((u64)1 << 1)
-#define LAYER_DOWN ((u64)1 << 2)
-#define LAYER_LEFT ((u64)1 << 3)
-#define LAYER_ALL (LAYER_UP | LAYER_RIGHT | LAYER_DOWN | LAYER_LEFT)
+#define RESOLVE_NONE ((u8)0)
+#define RESOLVE_UP ((u8)1 << 0)
+#define RESOLVE_RIGHT ((u8)1 << 1)
+#define RESOLVE_DOWN ((u8)1 << 2)
+#define RESOLVE_LEFT ((u8)1 << 3)
+#define RESOLVE_ALL (RESOLVE_UP | RESOLVE_RIGHT | RESOLVE_DOWN | RESOLVE_LEFT)
 
 // TODO(thismarvin): Naming components is hard...
 
@@ -106,8 +106,8 @@ typedef struct
 
 typedef struct
 {
-    // Layers you exist on.
-    u64 layer;
+    // The directions other entities will resolve against.
+    u8 resolutionSchema;
     // Layers you collide with.
     u64 mask;
     OnResolution onResolution;

--- a/src/ecs/entities/block.c
+++ b/src/ecs/entities/block.c
@@ -26,8 +26,8 @@ EntityBuilder BlockCreate(const f32 x, const f32 y, const f32 width, const f32 h
 
     ADD_COMPONENT(CCollider, ((CCollider)
     {
-        .layer = LAYER_ALL,
-        .mask = LAYER_NONE,
+        .resolutionSchema = RESOLVE_ALL,
+        .mask = RESOLVE_NONE,
     }));
 
     return (EntityBuilder)

--- a/src/ecs/entities/block.c
+++ b/src/ecs/entities/block.c
@@ -27,7 +27,8 @@ EntityBuilder BlockCreate(const f32 x, const f32 y, const f32 width, const f32 h
     ADD_COMPONENT(CCollider, ((CCollider)
     {
         .resolutionSchema = RESOLVE_ALL,
-        .mask = RESOLVE_NONE,
+        .layer = LAYER_TERRAIN,
+        .mask = LAYER_NONE,
     }));
 
     return (EntityBuilder)

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -96,7 +96,8 @@ EntityBuilder CloudParticleCreate
     ADD_COMPONENT(CCollider, ((CCollider)
     {
         .resolutionSchema = RESOLVE_NONE,
-        .mask = RESOLVE_ALL,
+        .layer = LAYER_NONE,
+        .mask = LAYER_TERRAIN,
         .onResolution = CloudParticleOnResolution,
         .onCollision = CloudParticleOnCollision,
     }));

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -95,8 +95,8 @@ EntityBuilder CloudParticleCreate
 
     ADD_COMPONENT(CCollider, ((CCollider)
     {
-        .layer = LAYER_NONE,
-        .mask = LAYER_ALL,
+        .resolutionSchema = RESOLVE_NONE,
+        .mask = RESOLVE_ALL,
         .onResolution = CloudParticleOnResolution,
         .onCollision = CloudParticleOnCollision,
     }));

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -177,7 +177,8 @@ EntityBuilder PlayerCreate(const f32 x, const f32 y)
     ADD_COMPONENT(CCollider, ((CCollider)
     {
         .resolutionSchema = RESOLVE_NONE,
-        .mask = RESOLVE_ALL,
+        .layer = LAYER_NONE,
+        .mask = LAYER_TERRAIN | LAYER_LETHAL,
         .onResolution = PlayerOnResolution,
         .onCollision = PlayerOnCollision,
     }));

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -176,8 +176,8 @@ EntityBuilder PlayerCreate(const f32 x, const f32 y)
 
     ADD_COMPONENT(CCollider, ((CCollider)
     {
-        .layer = LAYER_NONE,
-        .mask = LAYER_ALL,
+        .resolutionSchema = RESOLVE_NONE,
+        .mask = RESOLVE_ALL,
         .onResolution = PlayerOnResolution,
         .onCollision = PlayerOnCollision,
     }));

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -86,8 +86,8 @@ EntityBuilder WalkerCreate(const f32 x, const f32 y)
 
     ADD_COMPONENT(CCollider, ((CCollider)
     {
-        .layer = LAYER_ALL,
-        .mask = LAYER_ALL,
+        .resolutionSchema = RESOLVE_ALL,
+        .mask = RESOLVE_ALL,
         .onResolution = WalkerOnResolution,
         .onCollision = WalkerOnCollision,
     }));

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -87,7 +87,8 @@ EntityBuilder WalkerCreate(const f32 x, const f32 y)
     ADD_COMPONENT(CCollider, ((CCollider)
     {
         .resolutionSchema = RESOLVE_ALL,
-        .mask = RESOLVE_ALL,
+        .layer = LAYER_LETHAL,
+        .mask = LAYER_TERRAIN | LAYER_LETHAL,
         .onResolution = WalkerOnResolution,
         .onCollision = WalkerOnCollision,
     }));

--- a/src/ecs/systems.c
+++ b/src/ecs/systems.c
@@ -84,22 +84,22 @@ static Vector2 ExtractResolution(const Vector2 resolution, const u64 layers)
 {
     Vector2 result = VECTOR2_ZERO;
 
-    if ((layers & LAYER_LEFT) != 0 && resolution.x < 0)
+    if ((layers & RESOLVE_LEFT) != 0 && resolution.x < 0)
     {
         result.x = resolution.x;
     }
 
-    if ((layers & LAYER_RIGHT) != 0 && resolution.x > 0)
+    if ((layers & RESOLVE_RIGHT) != 0 && resolution.x > 0)
     {
         result.x = resolution.x;
     }
 
-    if ((layers & LAYER_UP) != 0 && resolution.y < 0)
+    if ((layers & RESOLVE_UP) != 0 && resolution.y < 0)
     {
         result.y = resolution.y;
     }
 
-    if ((layers & LAYER_DOWN) != 0 && resolution.y > 0)
+    if ((layers & RESOLVE_DOWN) != 0 && resolution.y > 0)
     {
         result.y = resolution.y;
     }
@@ -144,7 +144,7 @@ static SimulateCollisionOnAxisResult SimulateCollisionOnAxis
             const CDimension* otherDimension = SCENE_GET_COMPONENT_PTR(params->scene, otherDimension, i);
             const CCollider* otherCollider = SCENE_GET_COMPONENT_PTR(params->scene, otherCollider, i);
 
-            if ((params->collider->mask & otherCollider->layer) == 0)
+            if ((params->collider->mask & otherCollider->resolutionSchema) == 0)
             {
                 continue;
             }
@@ -160,7 +160,7 @@ static SimulateCollisionOnAxisResult SimulateCollisionOnAxis
             if (CheckCollisionRecs(simulatedAabb, otherAabb))
             {
                 Vector2 rawResolution = Vector2Create(-direction.x, -direction.y);
-                Vector2 resolution = ExtractResolution(rawResolution, otherCollider->layer);
+                Vector2 resolution = ExtractResolution(rawResolution, otherCollider->resolutionSchema);
 
                 // Check if extracting the resolution also invalidated the resolution.
                 if (resolution.x == 0 && resolution.y == 0)
@@ -393,7 +393,7 @@ void SCollisionUpdate(Scene* scene, const usize entity)
         const CDimension* otherDimension = SCENE_GET_COMPONENT_PTR(scene, otherDimension, i);
         const CCollider* otherCollider = SCENE_GET_COMPONENT_PTR(scene, otherCollider, i);
 
-        if ((collider->mask & otherCollider->layer) == 0)
+        if ((collider->mask & otherCollider->resolutionSchema) == 0)
         {
             continue;
         }

--- a/src/ecs/systems.c
+++ b/src/ecs/systems.c
@@ -144,7 +144,7 @@ static SimulateCollisionOnAxisResult SimulateCollisionOnAxis
             const CDimension* otherDimension = SCENE_GET_COMPONENT_PTR(params->scene, otherDimension, i);
             const CCollider* otherCollider = SCENE_GET_COMPONENT_PTR(params->scene, otherCollider, i);
 
-            if ((params->collider->mask & otherCollider->resolutionSchema) == 0)
+            if ((params->collider->mask & otherCollider->layer) == 0)
             {
                 continue;
             }
@@ -393,7 +393,7 @@ void SCollisionUpdate(Scene* scene, const usize entity)
         const CDimension* otherDimension = SCENE_GET_COMPONENT_PTR(scene, otherDimension, i);
         const CCollider* otherCollider = SCENE_GET_COMPONENT_PTR(scene, otherCollider, i);
 
-        if ((collider->mask & otherCollider->resolutionSchema) == 0)
+        if ((collider->mask & otherCollider->layer) == 0)
         {
             continue;
         }


### PR DESCRIPTION
A collider now has a `resolutionSchema` property that represents the directions other entities will resolve against. Moreover, the original Godot-inspired layer/mask system is back.

Hopefully everything makes sense this time around...