### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,16 +17,23 @@ Makefile.Desktop: src
 Makefile.Web: src
 	$(NU) -c "use scripts/generate.nu; generate makefile web | save Makefile.Web"
 
+.PHONY: @vendor/desktop
+@vendor/desktop:
+	$(MAKE) -f Makefile.Vendor @desktop
+
+.PHONY: @vendor/web
+@vendor/web:
+	$(MAKE) -f Makefile.Vendor @web
+
 .PHONY: @vendor
-@vendor: Makefile.Vendor
-	$(MAKE) -f Makefile.Vendor @vendor
+@vendor: @vendor/desktop @vendor/web
 
 .PHONY: @content
 @content: Makefile.Content
 	$(MAKE) -f Makefile.Content @content
 
 .PHONY: @desktop
-@desktop: @vendor @content Makefile.Desktop
+@desktop: @vendor/desktop @content Makefile.Desktop
 	$(MAKE) -f Makefile.Desktop @desktop
 
 	if [ -d "build/desktop/content" ]; then rm -r build/desktop/content; fi
@@ -34,7 +41,7 @@ Makefile.Web: src
 	cp -R build/content/. build/desktop/content
 
 .PHONY: @web
-@web: @vendor @content Makefile.Web
+@web: @vendor/web @content Makefile.Web
 	$(MAKE) -f Makefile.Web @web
 
 .PHONY: @dev
@@ -43,7 +50,7 @@ Makefile.Web: src
 	$(GPROF) build/desktop/ltlr build/desktop/gmon.out > build/desktop/profile
 
 .PHONY: @test
-@test: @vendor Makefile.Test
+@test: @vendor/desktop Makefile.Test
 	$(MAKE) -f Makefile.Test @test
 
 .PHONY: @format

--- a/Makefile.Test
+++ b/Makefile.Test
@@ -3,7 +3,7 @@ GPROF := gprof
 
 BIN := ltlr
 CFLAGS := -std=c17 -Wall -Wextra -Wpedantic -g -pg -O0 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_DESKTOP
-LDLIBS := -lm -lpthread -ldl -Llib/desktop -lraylib -lcJSON
+LDLIBS := -Llib/desktop -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -lcJSON
 
 DEPS := \
 	src/collections/deque.c \

--- a/Makefile.Vendor
+++ b/Makefile.Vendor
@@ -99,14 +99,14 @@ $(CJSON_WEB_OBJECTS): $(CJSON_SOURCES) | lib/web/cJSON
 lib/web/libcJSON.a: $(CJSON_WEB_OBJECTS) | lib/web
 	$(EMAR) rcs $@ $^
 
-.PHONY: @raylib
-@raylib: lib/desktop/libraylib.a lib/web/libraylib.a
+.PHONY: @desktop
+@desktop: lib/desktop/libraylib.a lib/desktop/libcJSON.a
 
-.PHONY: @cJSON
-@cJSON: lib/desktop/libcJSON.a lib/web/libcJSON.a
+.PHONY: @web
+@web: lib/web/libraylib.a lib/web/libcJSON.a
 
 .PHONY: @vendor
-@vendor: @raylib @cJSON
+@vendor: @desktop @web
 
 .PHONY: @clean
 @clean:

--- a/scripts/generate.nu
+++ b/scripts/generate.nu
@@ -246,7 +246,7 @@ CC := gcc
 
 BIN := ltlr
 CFLAGS := -std=c17 -Wall -Wextra -Wpedantic -g -pg -O0 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_DESKTOP
-LDLIBS := -lm -lpthread -ldl -Llib/desktop -lraylib -lcJSON
+LDLIBS := -Llib/desktop -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -lcJSON
 
 SOURCE_HEADERS := \\
 ($makefile-source-headers)

--- a/scripts/please.nu
+++ b/scripts/please.nu
@@ -190,7 +190,7 @@ export def build [
 
 	let ldlibs = (
 		if $target == 'linux' {
-			'-lm -lpthread -ldl -Llib/desktop -lraylib -lcJSON'
+			'-Llib/desktop -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -lcJSON'
 		} else if $target == 'windows' {
 			'-Llib/desktop -static -lraylib -lcJSON -lopengl32 -lgdi32 -lwinmm'
 		} else {


### PR DESCRIPTION
It turns out that our Makefile does not properly link all of the required libraries when targeting Linux...

Moreover, the `emscripten` toolchain is currently a hard dependency in our Makefile; in order to build the desktop version of ltlr, the user *must* have the `emsdk` setup locally.

The following changes will address both of these issues.