### PR TITLE
Safely working with Colliders

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -16,6 +16,8 @@ typedef size_t usize;
 typedef float f32;
 typedef double f64;
 
+#define UNUSED __attribute__((unused))
+
 #define MAX(mA,mB) (((mA)>(mB))?(mA):(mB))
 #define MIN(mA,mB) (((mA)<(mB))?(mA):(mB))
 

--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -43,8 +43,15 @@ typedef void (*OnDamage)(const OnDamageParams*);
 
 typedef struct
 {
+    Scene* scene;
+    usize entity;
     Rectangle aabb;
-} OnCollisionResult;
+    usize otherEntity;
+    Rectangle otherAabb;
+    Rectangle overlap;
+} OnCollisionParams;
+
+typedef void (*OnCollision)(const OnCollisionParams*);
 
 typedef struct
 {
@@ -63,18 +70,6 @@ typedef struct
 } OnResolutionParams;
 
 typedef OnResolutionResult (*OnResolution)(const OnResolutionParams*);
-
-typedef struct
-{
-    Scene* scene;
-    usize entity;
-    Rectangle aabb;
-    usize otherEntity;
-    Rectangle otherAabb;
-    Rectangle overlap;
-} OnCollisionParams;
-
-typedef void (*OnCollision)(const OnCollisionParams*);
 
 typedef struct
 {
@@ -117,8 +112,8 @@ typedef struct
     u64 layer;
     // Layers you collide with.
     u64 mask;
-    OnResolution onResolution;
     OnCollision onCollision;
+    OnResolution onResolution;
 } CCollider;
 
 // TODO(thismarvin): Should this be in some sort of Singleton?

--- a/src/ecs/entities/block.c
+++ b/src/ecs/entities/block.c
@@ -1,6 +1,16 @@
 #include "block.h"
 #include "common.h"
 
+static void BlockOnCollision() {}
+
+static OnResolutionResult BlockOnResolution(const OnResolutionParams* params)
+{
+    return (OnResolutionResult)
+    {
+        .aabb = params->aabb,
+    };
+}
+
 EntityBuilder BlockCreate(const Rectangle aabb, const u8 resolutionSchema, const u64 layer)
 {
     Deque components = DEQUE_OF(Component);
@@ -29,6 +39,8 @@ EntityBuilder BlockCreate(const Rectangle aabb, const u8 resolutionSchema, const
         .resolutionSchema = resolutionSchema,
         .layer = layer,
         .mask = LAYER_NONE,
+        .onCollision = BlockOnCollision,
+        .onResolution = BlockOnResolution,
     }));
 
     return (EntityBuilder)

--- a/src/ecs/entities/block.c
+++ b/src/ecs/entities/block.c
@@ -1,16 +1,6 @@
 #include "block.h"
 #include "common.h"
 
-static void BlockOnCollision() {}
-
-static OnResolutionResult BlockOnResolution(const OnResolutionParams* params)
-{
-    return (OnResolutionResult)
-    {
-        .aabb = params->aabb,
-    };
-}
-
 EntityBuilder BlockCreate(const Rectangle aabb, const u8 resolutionSchema, const u64 layer)
 {
     Deque components = DEQUE_OF(Component);
@@ -39,8 +29,8 @@ EntityBuilder BlockCreate(const Rectangle aabb, const u8 resolutionSchema, const
         .resolutionSchema = resolutionSchema,
         .layer = layer,
         .mask = LAYER_NONE,
-        .onCollision = BlockOnCollision,
-        .onResolution = BlockOnResolution,
+        .onCollision = OnCollisionNoop,
+        .onResolution = OnResolutionNoop,
     }));
 
     return (EntityBuilder)

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -2,6 +2,8 @@
 #include "common.h"
 #include <raymath.h>
 
+static void CloudParticleOnCollision() {}
+
 // TODO(thismarvin): The collider no longer scales...
 static OnResolutionResult CloudParticleOnResolution(const OnResolutionParams* params)
 {
@@ -29,8 +31,6 @@ static OnResolutionResult CloudParticleOnResolution(const OnResolutionParams* pa
         .aabb = resolvedAabb,
     };
 }
-
-static void CloudParticleOnCollision() {}
 
 EntityBuilder CloudParticleCreate
 (
@@ -98,8 +98,8 @@ EntityBuilder CloudParticleCreate
         .resolutionSchema = RESOLVE_NONE,
         .layer = LAYER_NONE,
         .mask = LAYER_TERRAIN,
-        .onResolution = CloudParticleOnResolution,
         .onCollision = CloudParticleOnCollision,
+        .onResolution = CloudParticleOnResolution,
     }));
 
     f32 lifetime = MIN(1.0f, (f32)GetRandomValue(1, 100) * 0.03f);

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -2,8 +2,6 @@
 #include "common.h"
 #include <raymath.h>
 
-static void CloudParticleOnCollision() {}
-
 // TODO(thismarvin): The collider no longer scales...
 static OnResolutionResult CloudParticleOnResolution(const OnResolutionParams* params)
 {
@@ -98,7 +96,7 @@ EntityBuilder CloudParticleCreate
         .resolutionSchema = RESOLVE_NONE,
         .layer = LAYER_NONE,
         .mask = LAYER_TERRAIN,
-        .onCollision = CloudParticleOnCollision,
+        .onCollision = OnCollisionNoop,
         .onResolution = CloudParticleOnResolution,
     }));
 

--- a/src/ecs/entities/common.c
+++ b/src/ecs/entities/common.c
@@ -30,3 +30,12 @@ Rectangle ApplyResolutionPerfectly
     return result;
 }
 
+void OnCollisionNoop(UNUSED const OnCollisionParams* params) {}
+
+OnResolutionResult OnResolutionNoop(const OnResolutionParams* params)
+{
+    return (OnResolutionResult)
+    {
+        .aabb = params->aabb,
+    };
+}

--- a/src/ecs/entities/common.h
+++ b/src/ecs/entities/common.h
@@ -16,3 +16,6 @@ Rectangle ApplyResolutionPerfectly
     Rectangle otherAabb,
     Vector2 resolution
 );
+
+void OnCollisionNoop(const OnCollisionParams* params);
+OnResolutionResult OnResolutionNoop(const OnResolutionParams* params);

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -1,6 +1,8 @@
 #include "common.h"
 #include "walker.h"
 
+static void WalkerOnCollision() {}
+
 static OnResolutionResult WalkerOnResolution(const OnResolutionParams* params)
 {
     assert(ENTITY_HAS_DEPS(params->entity, TAG_POSITION | TAG_KINETIC));
@@ -30,8 +32,6 @@ static OnResolutionResult WalkerOnResolution(const OnResolutionParams* params)
         .aabb = resolvedAabb,
     };
 }
-
-static void WalkerOnCollision() {}
 
 EntityBuilder WalkerCreate(const f32 x, const f32 y)
 {
@@ -89,8 +89,8 @@ EntityBuilder WalkerCreate(const f32 x, const f32 y)
         .resolutionSchema = RESOLVE_ALL,
         .layer = LAYER_LETHAL,
         .mask = LAYER_TERRAIN | LAYER_LETHAL,
-        .onResolution = WalkerOnResolution,
         .onCollision = WalkerOnCollision,
+        .onResolution = WalkerOnResolution,
     }));
 
     ADD_COMPONENT(CDamage, ((CDamage)
@@ -104,4 +104,3 @@ EntityBuilder WalkerCreate(const f32 x, const f32 y)
         .components = components,
     };
 }
-

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -1,8 +1,6 @@
 #include "common.h"
 #include "walker.h"
 
-static void WalkerOnCollision() {}
-
 static OnResolutionResult WalkerOnResolution(const OnResolutionParams* params)
 {
     assert(ENTITY_HAS_DEPS(params->entity, TAG_POSITION | TAG_KINETIC));
@@ -89,7 +87,7 @@ EntityBuilder WalkerCreate(const f32 x, const f32 y)
         .resolutionSchema = RESOLVE_ALL,
         .layer = LAYER_LETHAL,
         .mask = LAYER_TERRAIN | LAYER_LETHAL,
-        .onCollision = WalkerOnCollision,
+        .onCollision = OnCollisionNoop,
         .onResolution = WalkerOnResolution,
     }));
 


### PR DESCRIPTION
Block did not have its `onCollision` or `onResolution` callbacks defined. This wasn't necessary an issue, as blocks cannot collide with anything, but I decided to define them anyways just to be safe! 