### PR TITLE
Makefile Build Modes

### DIFF
--- a/Makefile.Test
+++ b/Makefile.Test
@@ -2,7 +2,7 @@ CC := gcc
 GPROF := gprof
 
 BIN := ltlr
-CFLAGS := -std=c17 -Wall -Wextra -Wpedantic -g -pg -O0 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_DESKTOP
+CFLAGS := -std=c17 -Wall -Wextra -Wpedantic -g -pg -Og -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_DESKTOP
 LDLIBS := -Llib/desktop -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -lcJSON
 
 DEPS := \

--- a/scripts/generate.nu
+++ b/scripts/generate.nu
@@ -245,7 +245,10 @@ $"# This file is auto-generated; any changes you make may be overwritten.
 CC := gcc
 
 BIN := ltlr
-CFLAGS := -std=c17 -Wall -Wextra -Wpedantic -g -pg -O0 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_DESKTOP
+BUILD := debug
+cflags.debug := -g -pg -Og
+cflags.release := -g -O2
+CFLAGS := -std=c17 -Wall -Wextra -Wpedantic $\(cflags.$\(BUILD)) -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_DESKTOP
 LDLIBS := -Llib/desktop -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -lcJSON
 
 SOURCE_HEADERS := \\

--- a/scripts/generate.nu
+++ b/scripts/generate.nu
@@ -365,7 +365,7 @@ $"# This file is auto-generated; any changes you make may be overwritten.
 
 EMCC := emcc
 
-CFLAGS := -std=c17 -Wall -Wextra -Wpedantic -O3 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_WEB
+CFLAGS := -std=c17 -Wall -Wextra -Wpedantic -g -O2 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_WEB
 LDLIBS := -Llib/web -lraylib -lcJSON
 
 TOTAL_MEMORY := 33554432

--- a/scripts/please.nu
+++ b/scripts/please.nu
@@ -182,9 +182,9 @@ export def build [
 	)
 	let optimization-flags = (
 		if not $release {
-			'-g -pg -O0'
+			'-g -pg -Og'
 		} else {
-			'-O2'
+			'-g -O2'
 		}
 	)
 
@@ -286,7 +286,7 @@ export def 'build web' [
 	with-env [
 		OUT_DIR $output-directory
 		EMCC 'emcc'
-		CFLAGS '-std=c17 -Wall -Wextra -Wpedantic -O2 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_WEB'
+		CFLAGS '-std=c17 -Wall -Wextra -Wpedantic -g -O2 -Ivendor/raylib/src -Ivendor/cJSON -DPLATFORM_WEB'
 		LDLIBS '-Llib/web -lraylib -lcJSON'
 		SHELL_FILE 'src/minshell.html'
 		TOTAL_MEMORY '33554432'


### PR DESCRIPTION
Our generated `Makefile.Desktop` does not (easily) support building with optimization levels other than the default. Considering that our `nu` scripts does support debug and release modes, it would be cool if our makefile also supported said functionality.

It turns out that this is very easy to implement! See [this](https://stackoverflow.com/a/8039408) Stack Overflow answer for more information.

Moving forward, building with more optimizations enabled looks like this:

``` shell
make @desktop BUILD=release
```