### PR TITLE
Add `void` to Functions with Empty Prototypes

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -3,12 +3,12 @@
 static f64 totalTime = 0.0;
 static f32 alpha = 0.0;
 
-// f32 ContextGetDeltaTime()
+// f32 ContextGetDeltaTime(void)
 // {
 //     return CTX_DT;
 // }
 
-f64 ContextGetTotalTime()
+f64 ContextGetTotalTime(void)
 {
     return totalTime;
 }
@@ -18,7 +18,7 @@ void ContextSetTotalTime(const f64 value)
     totalTime = value;
 }
 
-f32 ContextGetAlpha()
+f32 ContextGetAlpha(void)
 {
     return alpha;
 }

--- a/src/context.h
+++ b/src/context.h
@@ -11,8 +11,8 @@
 // Target (fixed) delta time.
 #define CTX_DT (1.0 / 60.0)
 
-// f32 ContextGetDeltaTime();
-f64 ContextGetTotalTime();
+// f32 ContextGetDeltaTime(void);
+f64 ContextGetTotalTime(void);
 void ContextSetTotalTime(f64 value);
-f32 ContextGetAlpha();
+f32 ContextGetAlpha(void);
 void ContextSetAlpha(f32 value);

--- a/src/ecs/entities/fog.c
+++ b/src/ecs/entities/fog.c
@@ -11,7 +11,7 @@
     .y = -(FOG_HEIGHT - CTX_VIEWPORT_HEIGHT) * 0.5f, \
 }
 
-EntityBuilder FogCreate()
+EntityBuilder FogCreate(void)
 {
     Deque components = DEQUE_OF(Component);
 

--- a/src/ecs/entities/fog.h
+++ b/src/ecs/entities/fog.h
@@ -3,7 +3,7 @@
 #include "../../scene.h"
 #include "../entity_builder.h"
 
-EntityBuilder FogCreate();
+EntityBuilder FogCreate(void);
 
 void FogUpdate(Scene* scene, usize entity);
 void FogDraw(const Scene* scene, usize entity);

--- a/src/ecs/events.c
+++ b/src/ecs/events.c
@@ -2,7 +2,7 @@
 #include "events.h"
 #include <raymath.h>
 
-EventHandler EventHandlerCreate()
+EventHandler EventHandlerCreate(void)
 {
     return (EventHandler)
     {

--- a/src/ecs/events.h
+++ b/src/ecs/events.h
@@ -10,7 +10,7 @@ typedef struct
     Deque listeners;
 } EventHandler;
 
-EventHandler EventHandlerCreate();
+EventHandler EventHandlerCreate(void);
 void EventHandlerSubscribe(EventHandler* self, OnRaise onRaise);
 void EventHandlerRaise(const EventHandler* self, const void* arguments);
 void EventHandlerDestroy(EventHandler* self);

--- a/src/input.h
+++ b/src/input.h
@@ -89,7 +89,7 @@ void InputProfileAddGamepadBinding(InputProfile* self, GamepadBinding binding);
 void InputProfileAddMouseBinding(InputProfile* self, MouseBinding binding);
 void InputProfileAddAxisBinding(InputProfile* self, AxisBinding binding);
 
-InputHandler InputHandlerCreate();
+InputHandler InputHandlerCreate(usize gamepad);
 void InputHandlerSetProfile(InputHandler* self, InputProfile profile);
 void InputHandlerUpdate(InputHandler* self);
 // TODO(thismarvin): Return the active bindings somehow...

--- a/src/scene.c
+++ b/src/scene.c
@@ -757,12 +757,12 @@ static void SceneDrawLayers(const Scene* self)
     EndDrawing();
 }
 
-static void RenderRootLayer()
+static void RenderRootLayer(UNUSED const RenderFnParams* params)
 {
     ClearBackground(P8_BLUE);
 }
 
-static void RenderBackgroundLayer()
+static void RenderBackgroundLayer(UNUSED const RenderFnParams* params)
 {
     ClearBackground(COLOR_TRANSPARENT);
 

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -43,7 +43,7 @@ static bool DequeTestPushFrontMultiple(void)
     return result;
 }
 
-static bool DequeTestPushBack1()
+static bool DequeTestPushBack1(void)
 {
     Deque deque = DEQUE_OF(i32);
     DEQUE_PUSH_BACK(&deque, i32, 1);


### PR DESCRIPTION
The following changes will address the `-Wstrict-prototypes` warning. Also, we can now use the `UNUSED` macro to prevent this from happening again in the future!