### PR TITLE
Update nu Scripts to Support v0.63.0

### DIFF
--- a/scripts/bootstrap.nu
+++ b/scripts/bootstrap.nu
@@ -12,15 +12,15 @@ export def "bootstrapper lib" [] {
 	cd vendor/raylib/src
 	^$env.MAKE PLATFORM=PLATFORM_DESKTOP CUSTOM_CFLAGS=-DSUPPORT_CUSTOM_FRAME_CONTROL
 	cd ../../../
-	mv -q vendor/raylib/src/raudio.o lib/desktop/raylib
-	mv -q vendor/raylib/src/rcore.o lib/desktop/raylib
-	mv -q vendor/raylib/src/rglfw.o lib/desktop/raylib
-	mv -q vendor/raylib/src/rmodels.o lib/desktop/raylib
-	mv -q vendor/raylib/src/rshapes.o lib/desktop/raylib
-	mv -q vendor/raylib/src/rtext.o lib/desktop/raylib
-	mv -q vendor/raylib/src/rtextures.o lib/desktop/raylib
-	mv -q vendor/raylib/src/utils.o lib/desktop/raylib
-	mv -q vendor/raylib/src/libraylib.a lib/desktop
+	mv vendor/raylib/src/raudio.o lib/desktop/raylib
+	mv vendor/raylib/src/rcore.o lib/desktop/raylib
+	mv vendor/raylib/src/rglfw.o lib/desktop/raylib
+	mv vendor/raylib/src/rmodels.o lib/desktop/raylib
+	mv vendor/raylib/src/rshapes.o lib/desktop/raylib
+	mv vendor/raylib/src/rtext.o lib/desktop/raylib
+	mv vendor/raylib/src/rtextures.o lib/desktop/raylib
+	mv vendor/raylib/src/utils.o lib/desktop/raylib
+	mv vendor/raylib/src/libraylib.a lib/desktop
 
 	^$env.CC -std=c89 -O1 -o lib/desktop/cJSON/cJSON.o -c vendor/cJSON/cJSON.c
 	^$env.AR rcs lib/desktop/libcJSON.a lib/desktop/cJSON/cJSON.o

--- a/scripts/please.nu
+++ b/scripts/please.nu
@@ -36,12 +36,12 @@ export def "builder content" [
 	do {
 		let _ = {
 			(ls $"($env.OUT_DIR)/**/*.png").name
-			| each { |it| rm -q $it }
+			| each { |it| rm $it }
 		}
 
 		let _ = {
 			(ls $"($env.OUT_DIR)/**/*.json").name
-			| each { |it| rm -q $it }
+			| each { |it| rm $it }
 		}
 	}
 


### PR DESCRIPTION
It seems that latest release removed the `-q` flag (as it is now the default behavior).