### PR TITLE
Fixing `Quadtree`

### DIFF
--- a/Makefile.Test
+++ b/Makefile.Test
@@ -7,6 +7,8 @@ LDLIBS := -Llib/desktop -lraylib -lGL -lm -lpthread -ldl -lrt -lX11 -lcJSON
 
 DEPS := \
 	src/collections/deque.c \
+	src/common.c \
+	src/utils/quadtree.c \
 	tests/testing.c \
 
 $(VERBOSE).SILENT:

--- a/src/common.c
+++ b/src/common.c
@@ -9,22 +9,22 @@ Vector2 Vector2Create(const f32 x, const f32 y)
     };
 }
 
-f32 RectangleLeft(const Rectangle rectangle)
+f32 RectangleLeft(const Rectangle self)
 {
-    return rectangle.x;
+    return self.x;
 }
 
-f32 RectangleRight(const Rectangle rectangle)
+f32 RectangleRight(const Rectangle self)
 {
-    return rectangle.x + rectangle.width;
+    return self.x + self.width;
 }
 
-f32 RectangleBottom(const Rectangle rectangle)
+f32 RectangleBottom(const Rectangle self)
 {
-    return rectangle.y + rectangle.height;
+    return self.y + self.height;
 }
 
-f32 RectangleTop(const Rectangle rectangle)
+f32 RectangleTop(const Rectangle self)
 {
-    return rectangle.y;
+    return self.y;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -28,3 +28,11 @@ f32 RectangleTop(const Rectangle self)
 {
     return self.y;
 }
+
+bool RectangleContains(const Rectangle self, const Rectangle other)
+{
+    return RectangleLeft(other) >= RectangleLeft(self)
+           && RectangleRight(other) <= RectangleRight(self)
+           && RectangleTop(other) >= RectangleTop(self)
+           && RectangleBottom(other) <= RectangleBottom(self);
+}

--- a/src/common.h
+++ b/src/common.h
@@ -36,3 +36,4 @@ f32 RectangleLeft(Rectangle self);
 f32 RectangleRight(Rectangle self);
 f32 RectangleBottom(Rectangle self);
 f32 RectangleTop(Rectangle self);
+bool RectangleContains(Rectangle self, Rectangle other);

--- a/src/common.h
+++ b/src/common.h
@@ -32,7 +32,7 @@ typedef double f64;
 
 Vector2 Vector2Create(f32 x, f32 y);
 
-f32 RectangleLeft(Rectangle rectangle);
-f32 RectangleRight(Rectangle rectangle);
-f32 RectangleBottom(Rectangle rectangle);
-f32 RectangleTop(Rectangle rectangle);
+f32 RectangleLeft(Rectangle self);
+f32 RectangleRight(Rectangle self);
+f32 RectangleBottom(Rectangle self);
+f32 RectangleTop(Rectangle self);

--- a/src/utils/quadtree.c
+++ b/src/utils/quadtree.c
@@ -127,12 +127,16 @@ Deque QuadtreeQuery(const Quadtree* self, const Rectangle region)
 
 void QuadtreeClear(Quadtree* self)
 {
-    self->headIndex = 0;
-
     QuadtreeDestroy(self->topLeft);
     QuadtreeDestroy(self->topRight);
     QuadtreeDestroy(self->bottomRight);
     QuadtreeDestroy(self->bottomLeft);
+
+    self->headIndex = 0;
+    self->topLeft = NULL;
+    self->topRight = NULL;
+    self->bottomRight = NULL;
+    self->bottomLeft = NULL;
 }
 
 void QuadtreeDestroy(Quadtree* self)

--- a/src/utils/quadtree.c
+++ b/src/utils/quadtree.c
@@ -127,16 +127,17 @@ Deque QuadtreeQuery(const Quadtree* self, const Rectangle region)
 
 void QuadtreeClear(Quadtree* self)
 {
-    QuadtreeDestroy(self->topLeft);
-    QuadtreeDestroy(self->topRight);
-    QuadtreeDestroy(self->bottomRight);
-    QuadtreeDestroy(self->bottomLeft);
+    if (self == NULL)
+    {
+        return;
+    }
+
+    QuadtreeClear(self->topLeft);
+    QuadtreeClear(self->topRight);
+    QuadtreeClear(self->bottomRight);
+    QuadtreeClear(self->bottomLeft);
 
     self->headIndex = 0;
-    self->topLeft = NULL;
-    self->topRight = NULL;
-    self->bottomRight = NULL;
-    self->bottomLeft = NULL;
 }
 
 void QuadtreeDestroy(Quadtree* self)

--- a/src/utils/quadtree.c
+++ b/src/utils/quadtree.c
@@ -1,16 +1,17 @@
 #include "quadtree.h"
 
-Quadtree QuadtreeCreate(const Rectangle region)
+Quadtree* QuadtreeNew(Rectangle region)
 {
-    return (Quadtree)
-    {
-        .region = region,
-        .headIndex = 0,
-        .topLeft = NULL,
-        .topRight = NULL,
-        .bottomLeft = NULL,
-        .bottomRight = NULL,
-    };
+    Quadtree* quadtree = malloc(sizeof(Quadtree));
+
+    quadtree->region = region;
+    quadtree->headIndex = 0;
+    quadtree->topLeft = NULL;
+    quadtree->topRight = NULL;
+    quadtree->bottomLeft = NULL;
+    quadtree->bottomRight = NULL;
+
+    return quadtree;
 }
 
 static bool QuadtreeHasDivided(const Quadtree* self)
@@ -58,17 +59,10 @@ static void QuadtreeSubdivide(Quadtree* self)
         .height = height,
     };
 
-    self->topLeft = (Quadtree*)malloc(sizeof(Quadtree));
-    *self->topLeft = QuadtreeCreate(topLeft);
-
-    self->topRight = (Quadtree*)malloc(sizeof(Quadtree));
-    *self->topRight = QuadtreeCreate(topRight);
-
-    self->bottomLeft = (Quadtree*)malloc(sizeof(Quadtree));
-    *self->bottomLeft = QuadtreeCreate(bottomLeft);
-
-    self->bottomRight = (Quadtree*)malloc(sizeof(Quadtree));
-    *self->bottomRight = QuadtreeCreate(bottomRight);
+    self->topLeft = QuadtreeNew(topLeft);
+    self->topRight = QuadtreeNew(topRight);
+    self->bottomLeft = QuadtreeNew(bottomLeft);
+    self->bottomRight = QuadtreeNew(bottomRight);
 }
 
 bool QuadtreeAdd(Quadtree* self, const usize entity, const Rectangle aabb)

--- a/src/utils/quadtree.h
+++ b/src/utils/quadtree.h
@@ -3,20 +3,12 @@
 #include "../collections/deque.h"
 #include "../common.h"
 
-#define QUADTREE_CAPACITY 4
-
-typedef struct
-{
-    Rectangle region;
-    usize entity;
-} QuadtreeEntry;
-
 struct Quadtree
 {
     Rectangle region;
-    QuadtreeEntry entries[QUADTREE_CAPACITY];
-    usize headIndex;
-
+    u8 maxDepth;
+    u8 depth;
+    Deque entries;
     struct Quadtree* topLeft;
     struct Quadtree* topRight;
     struct Quadtree* bottomLeft;
@@ -25,8 +17,8 @@ struct Quadtree
 
 typedef struct Quadtree Quadtree;
 
-Quadtree* QuadtreeNew(Rectangle region);
-bool QuadtreeAdd(Quadtree* self, usize entity, Rectangle aabb);
+Quadtree* QuadtreeNew(Rectangle region, u8 maxDepth);
+bool QuadtreeAdd(Quadtree* self, usize id, Rectangle aabb);
 Deque QuadtreeQuery(const Quadtree* self, Rectangle region);
 void QuadtreeClear(Quadtree* self);
 void QuadtreeDestroy(Quadtree* self);

--- a/src/utils/quadtree.h
+++ b/src/utils/quadtree.h
@@ -25,7 +25,7 @@ struct Quadtree
 
 typedef struct Quadtree Quadtree;
 
-Quadtree QuadtreeCreate(Rectangle region);
+Quadtree* QuadtreeNew(Rectangle region);
 bool QuadtreeAdd(Quadtree* self, usize entity, Rectangle aabb);
 Deque QuadtreeQuery(const Quadtree* self, Rectangle region);
 void QuadtreeClear(Quadtree* self);

--- a/tests/unit_tests.c
+++ b/tests/unit_tests.c
@@ -1,3 +1,4 @@
+#include "../src/utils/quadtree.h"
 #include "testing.h"
 #include <stdint.h>
 
@@ -230,10 +231,324 @@ static bool ExecuteDequeTests(void)
     return TestSuitePresentResults(&suite);
 }
 
+static bool TestQuadtreeNew(void)
+{
+    const Rectangle region = (Rectangle)
+    {
+        .x = 0,
+        .y = 0,
+        .width = 100,
+        .height = 100,
+    };
+    Quadtree* quadtree = QuadtreeNew(region, 4);
+
+    QuadtreeDestroy(quadtree);
+
+    return true;
+}
+
+static bool TestQuadtreeAdd(void)
+{
+    const Rectangle region = (Rectangle)
+    {
+        .x = 0,
+        .y = 0,
+        .width = 100,
+        .height = 100,
+    };
+    Quadtree* quadtree = QuadtreeNew(region, 4);
+
+    usize totalAdded = 0;
+
+    // Add something that is completely contained in the Quadtree's region (and small).
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 8,
+            .y = 8,
+            .width = 4,
+            .height = 8,
+        };
+
+        if (QuadtreeAdd(quadtree, 1, aabb))
+        {
+            totalAdded += 1;
+        }
+    }
+    // Add something that is completely contained in the Quadtree's region (and very wide).
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 15,
+            .y = 75,
+            .width = 60,
+            .height = 10,
+        };
+
+        if (QuadtreeAdd(quadtree, 1, aabb))
+        {
+            totalAdded += 1;
+        }
+    }
+    // Add something that is partially within the Quadtree's region.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 80,
+            .y = 16,
+            .width = 64,
+            .height = 32,
+        };
+
+        if (QuadtreeAdd(quadtree, 2, aabb))
+        {
+            totalAdded += 1;
+        }
+    }
+    // Attempt to add something that is completely outside the Quadtree's region.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 58008,
+            .y = 1337,
+            .width = 42,
+            .height = 42,
+        };
+
+        if (QuadtreeAdd(quadtree, 3, aabb))
+        {
+            totalAdded += 1;
+        }
+    }
+
+    QuadtreeDestroy(quadtree);
+
+    return totalAdded == 1 + 1 + 0 + 0;
+}
+
+static bool TestQuadtreeQuery(void)
+{
+    const Rectangle region = (Rectangle)
+    {
+        .x = 0,
+        .y = 0,
+        .width = 100,
+        .height = 100,
+    };
+    Quadtree* quadtree = QuadtreeNew(region, 4);
+
+    QuadtreeAdd(quadtree, 1, (Rectangle)
+    {
+        10, 10, 30, 30
+    });
+    QuadtreeAdd(quadtree, 2, (Rectangle)
+    {
+        60, 10, 30, 30
+    });
+    QuadtreeAdd(quadtree, 3, (Rectangle)
+    {
+        10, 60, 30, 30
+    });
+    QuadtreeAdd(quadtree, 4, (Rectangle)
+    {
+        5, 5, 80, 30
+    });
+
+    for (usize i = 0; i < 5; ++i)
+    {
+        QuadtreeAdd(quadtree, 5 + i, (Rectangle)
+        {
+            80 + i, 80 + i, 1, 1
+        });
+    }
+
+    usize totalHits = 0;
+
+    // Query over a single quadrant.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 50,
+            .y = 0,
+            .width = 50,
+            .height = 50,
+        };
+        Deque queryResults = QuadtreeQuery(quadtree, aabb);
+
+        totalHits += DequeGetSize(&queryResults);
+
+        DequeDestroy(&queryResults);
+    }
+    // Query over multiple quadrants.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 0,
+            .y = 0,
+            .width = 100,
+            .height = 50,
+        };
+        Deque queryResults = QuadtreeQuery(quadtree, aabb);
+
+        totalHits += DequeGetSize(&queryResults);
+
+        DequeDestroy(&queryResults);
+    }
+    // Query over an empty region.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 0,
+            .y = 90,
+            .width = 100,
+            .height = 200,
+        };
+        Deque queryResults = QuadtreeQuery(quadtree, aabb);
+
+        totalHits += DequeGetSize(&queryResults);
+
+        DequeDestroy(&queryResults);
+    }
+    // Query over a region completely outside of the Quadtree's region.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 111111,
+            .y = 101110,
+            .width = 500,
+            .height = 500,
+        };
+        Deque queryResults = QuadtreeQuery(quadtree, aabb);
+
+        totalHits += DequeGetSize(&queryResults);
+
+        DequeDestroy(&queryResults);
+    }
+
+    QuadtreeDestroy(quadtree);
+
+    return totalHits == 2 + 3 + 0 + 0;
+}
+
+static bool TestQuadtreeClear(void)
+{
+    const Rectangle region = (Rectangle)
+    {
+        .x = 0,
+        .y = 0,
+        .width = 100,
+        .height = 100,
+    };
+    Quadtree* quadtree = QuadtreeNew(region, 4);
+
+    for (usize i = 0; i < 50; ++i)
+    {
+        QuadtreeAdd(quadtree, i, (Rectangle)
+        {
+            i, 0, 16, 16
+        });
+    }
+
+    usize totalHits = 0;
+
+    // Query over the entire Quadtree.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = -100,
+            .y = -100,
+            .width = 12345,
+            .height = 12345,
+        };
+        Deque queryResults = QuadtreeQuery(quadtree, aabb);
+
+        totalHits += DequeGetSize(&queryResults);
+
+        DequeDestroy(&queryResults);
+    }
+
+    QuadtreeClear(quadtree);
+
+    // Query over the entire (empty) Quadtree.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = -100,
+            .y = -100,
+            .width = 12345,
+            .height = 12345,
+        };
+        Deque queryResults = QuadtreeQuery(quadtree, aabb);
+
+        totalHits += DequeGetSize(&queryResults);
+
+        DequeDestroy(&queryResults);
+    }
+
+    // Attempt to repurpose the existing Quadtree.
+    {
+        usize entityIndex = 1;
+
+        for (usize i = 0; i < 50; ++i)
+        {
+            QuadtreeAdd(quadtree, entityIndex + i, (Rectangle)
+            {
+                25 + i, 60, 16, 16
+            });
+
+            entityIndex += 1;
+        }
+
+        for (usize i = 0; i < 50; ++i)
+        {
+            QuadtreeAdd(quadtree, entityIndex + i, (Rectangle)
+            {
+                25 + i, 0, 16, 16
+            });
+
+            entityIndex += 1;
+        }
+    }
+
+    // Query over the bottom half of the Quadtree.
+    {
+        const Rectangle aabb = (Rectangle)
+        {
+            .x = 0,
+            .y = 50,
+            .width = 100,
+            .height = 100,
+        };
+        Deque queryResults = QuadtreeQuery(quadtree, aabb);
+
+        totalHits += DequeGetSize(&queryResults);
+
+        DequeDestroy(&queryResults);
+    }
+
+    QuadtreeDestroy(quadtree);
+
+    return totalHits == 50 + 0 + 50;
+}
+
+static bool ExecuteQuadtreeTests(void)
+{
+    TestSuite suite = TestSuiteCreate("Quadtree Tests");
+
+    TestSuiteAdd(&suite, "Create an empty Quadtree", TestQuadtreeNew);
+    TestSuiteAdd(&suite, "Add entries to a Quadtree", TestQuadtreeAdd);
+    TestSuiteAdd(&suite, "Query a Quadtree", TestQuadtreeQuery);
+    TestSuiteAdd(&suite, "Clear a Quadtree", TestQuadtreeClear);
+
+    return TestSuitePresentResults(&suite);
+}
+
 int main(void)
 {
     bool allPass = true;
+
     allPass &= ExecuteDequeTests();
+    allPass &= ExecuteQuadtreeTests();
 
     if (!allPass)
     {


### PR DESCRIPTION
Long story short, our Quadtree implementation only works on points; we actually need it to work on regions.

The following changes implement proper support for regions, address a couple nasty bugs, and even add unit tests.