### PR TITLE
Implement Image Mirroring

### DIFF
--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -32,6 +32,15 @@
 
 typedef struct Scene Scene;
 
+typedef enum
+{
+    FLIP_NONE = 0,
+    // Reverse the x-axis of the sprite.
+    FLIP_HORIZONTAL = 1 << 0,
+    // Reverse the y-axis of the sprite.
+    FLIP_VERTICAL = 1 << 1,
+} SpriteMirroring;
+
 typedef struct
 {
     Scene* scene;
@@ -91,6 +100,7 @@ typedef struct
 {
     Rectangle source;
     Vector2 offset;
+    SpriteMirroring mirroring;
 } CSprite;
 
 typedef struct

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -161,6 +161,7 @@ EntityBuilder PlayerCreate(const f32 x, const f32 y)
     {
         .source = (Rectangle) { 16, 0, 32, 48 },
         .offset = Vector2Create(-8, -13),
+        .mirroring = FLIP_NONE,
     }));
 
     ADD_COMPONENT(CKinetic, ((CKinetic)

--- a/src/ecs/entities/walker.c
+++ b/src/ecs/entities/walker.c
@@ -69,6 +69,7 @@ EntityBuilder WalkerCreate(const f32 x, const f32 y)
     {
         .source = (Rectangle) { 3 * 16, 5 * 16, 16, 16 },
         .offset = VECTOR2_ZERO,
+        .mirroring = FLIP_NONE,
     }));
 
     ADD_COMPONENT(CKinetic, ((CKinetic)

--- a/src/ecs/systems.c
+++ b/src/ecs/systems.c
@@ -447,21 +447,28 @@ void SSpriteDraw(const Scene* scene, const usize entity)
     const CColor* color = GET_COMPONENT(color, entity);
     const CSprite* sprite = GET_COMPONENT(sprite, entity);
 
+    Vector2 drawPosition = Vector2Add(position->value, sprite->offset);
+    Rectangle source = sprite->source;
+
     if (ENTITY_HAS_DEPS(entity, TAG_SMOOTH))
     {
         const CSmooth* smooth = GET_COMPONENT(smooth, entity);
 
-        Vector2 interpolated = Vector2Lerp(smooth->previous, position->value, ContextGetAlpha());
-        Vector2 drawPosition = Vector2Add(interpolated, sprite->offset);
-
-        DrawTextureRec(scene->atlas, sprite->source, drawPosition, color->value);
+        const Vector2 interpolated = Vector2Lerp(smooth->previous, position->value, ContextGetAlpha());
+        drawPosition = Vector2Add(interpolated, sprite->offset);
     }
-    else
+
+    if ((sprite->mirroring & FLIP_HORIZONTAL) != 0)
     {
-        Vector2 drawPosition = Vector2Add(position->value, sprite->offset);
-
-        DrawTextureRec(scene->atlas, sprite->source, drawPosition, color->value);
+        source.width = -sprite->source.width;
     }
+
+    if ((sprite->mirroring & FLIP_VERTICAL) != 0)
+    {
+        source.height = -sprite->source.height;
+    }
+
+    DrawTextureRec(scene->atlas, source, drawPosition, color->value);
 }
 
 void SDebugDraw(const Scene* scene, const usize entity)


### PR DESCRIPTION
Supporting image mirroring is a necessity for the upcoming animation logic. The implementation itself was relatively straightforward; however, occasionally there are some visual artifacts (but it's a problem upstream?).