### PR TITLE
Implement Deferred Scene Resetting 

### DIFF
--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -430,8 +430,7 @@ void PlayerMortalUpdate(Scene* scene, const usize entity)
 
     if (position->value.y > CTX_VIEWPORT_HEIGHT * 2)
     {
-        // TODO(thismarvin): Defer resetting the Scene somehow...
-        SceneReset(scene);
+        SceneDeferReset(scene);
 
         return;
     }

--- a/src/scene.c
+++ b/src/scene.c
@@ -547,7 +547,6 @@ void SceneUpdate(Scene* self)
     }
 
     SceneExecuteCommands(self);
-    SceneCheckEndCondition(self);
 
     for (usize i = 0; i < SceneGetEntityCount(self); ++i)
     {
@@ -566,6 +565,8 @@ void SceneUpdate(Scene* self)
 
         FogUpdate(self, i);
     }
+
+    SceneCheckEndCondition(self);
 }
 
 // Return a Rectangle that is within the scene's bounds and centered on a given entity.

--- a/src/scene.c
+++ b/src/scene.c
@@ -494,6 +494,16 @@ static void SceneStart(Scene* self)
     SceneDeferAddEntity(self, WalkerCreate(16 * 16, 16 * 8));
 }
 
+static void SceneReset(Scene* self)
+{
+    DequeDestroy(&self->commands);
+    DequeDestroy(&self->m_entityManager.m_recycledEntityIndices);
+
+    SceneStart(self);
+
+    self->resetRequested = false;
+}
+
 void SceneInit(Scene* self)
 {
     SceneSetupContent(self);
@@ -518,7 +528,7 @@ static void SceneCheckEndCondition(Scene* self)
 
     if (distance > CTX_VIEWPORT_WIDTH * 0.5f)
     {
-        SceneReset(self);
+        SceneDeferReset(self);
     }
 }
 
@@ -529,6 +539,11 @@ void SceneUpdate(Scene* self)
     if (IsKeyPressed(KEY_EQUAL))
     {
         self->debugging = !self->debugging;
+    }
+
+    if (self->resetRequested)
+    {
+        SceneReset(self);
     }
 
     SceneExecuteCommands(self);
@@ -819,12 +834,9 @@ void SceneDraw(const Scene* self)
     SceneDrawLayers(self);
 }
 
-void SceneReset(Scene* self)
+void SceneDeferReset(Scene* self)
 {
-    DequeDestroy(&self->commands);
-    DequeDestroy(&self->m_entityManager.m_recycledEntityIndices);
-
-    SceneStart(self);
+    self->resetRequested = true;
 }
 
 void SceneDestroy(Scene* self)

--- a/src/scene.h
+++ b/src/scene.h
@@ -55,6 +55,7 @@ struct Scene
     // TODO(thismarvin): Should this exist in Scene?
     InputHandler input;
     Deque commands;
+    bool resetRequested;
 };
 
 void SceneInit(Scene* self);
@@ -69,7 +70,7 @@ void SceneSubmitCommand(Scene* self, Command command);
 void SceneExecuteCommands(Scene* self);
 void SceneUpdate(Scene* self);
 void SceneDraw(const Scene* self);
-void SceneReset(Scene* self);
+void SceneDeferReset(Scene* self);
 void SceneDestroy(Scene* self);
 
 #define SCENE_GET_COMPONENT(mScene, mValue, mEntity) _Generic((mValue), \


### PR DESCRIPTION
Resetting the `Scene` in-place is asking for trouble! We already have a mechanism to defer ECS operations, so deferring `Scene` specific logic should be fairly straightforward.

With that said, I opted to not use our current infrastructure (i.e. `Command`); instead, I sort of just slapped on the logic to `Scene` itself. `Command` seems too coupled with our ECS (it literally exists in the `ecs` directory) to just add a very `Scene` specific command.

What do you think? Should we just merge these changes, add a reset command, or rethink where `command.c` and `scene.c` exist?