### PR TITLE
Better/Cooler Cloud Particles

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -20,6 +20,7 @@ typedef double f64;
 
 #define MAX(mA,mB) (((mA)>(mB))?(mA):(mB))
 #define MIN(mA,mB) (((mA)<(mB))?(mA):(mB))
+#define SIGN(mA) ((mA) == 0 ? 0 : (mA) < 0 ? -1 : 1)
 
 #define VECTOR2_ZERO (Vector2) { .x = 0, .y = 0 }
 

--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -143,10 +143,6 @@ typedef struct
     f32 coyoteDuration;
     bool jumping;
     bool dead;
-    f32 moveSpeed;
-    f32 jumpVelocity;
-    f32 jumpGravity;
-    f32 defaultGravity;
     Vector2 gravityForce;
     f32 invulnerableTimer;
     f32 invulnerableDuration;

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -35,7 +35,8 @@ EntityBuilder CloudParticleCreate
     const Vector2 position,
     const f32 radius,
     const Vector2 initialVelocity,
-    const Vector2 acceleration
+    const Vector2 acceleration,
+    const f32 lifetime
 )
 {
     Deque components = DEQUE_OF(Component);
@@ -85,8 +86,6 @@ EntityBuilder CloudParticleCreate
         .onCollision = OnCollisionNoop,
         .onResolution = CloudParticleOnResolution,
     }));
-
-    f32 lifetime = MIN(1.0f, (f32)GetRandomValue(1, 100) * 0.03f);
 
     ADD_COMPONENT(CFleeting, ((CFleeting)
     {

--- a/src/ecs/entities/cloud_particle.c
+++ b/src/ecs/entities/cloud_particle.c
@@ -32,9 +32,10 @@ static OnResolutionResult CloudParticleOnResolution(const OnResolutionParams* pa
 
 EntityBuilder CloudParticleCreate
 (
-    const f32 centerX,
-    const f32 centerY,
-    const Vector2 direction
+    const Vector2 position,
+    const f32 radius,
+    const Vector2 initialVelocity,
+    const Vector2 acceleration
 )
 {
     Deque components = DEQUE_OF(Component);
@@ -48,19 +49,6 @@ EntityBuilder CloudParticleCreate
         | TAG_SMOOTH
         | TAG_COLLIDER
         | TAG_FLEETING;
-
-    f32 radius = 1;
-
-    if (GetRandomValue(1, 100) < 25)
-    {
-        radius = (f32) GetRandomValue(4, 5);
-    }
-    else
-    {
-        radius = (f32)GetRandomValue(1, 3);
-    }
-
-    Vector2 position = Vector2Create(centerX - radius, centerY - radius);
 
     ADD_COMPONENT(CPosition, ((CPosition)
     {
@@ -78,12 +66,10 @@ EntityBuilder CloudParticleCreate
         .value = COLOR_WHITE,
     }));
 
-    f32 speed = (f32)GetRandomValue(5, 15);
-
     ADD_COMPONENT(CKinetic, ((CKinetic)
     {
-        .velocity = Vector2Scale(direction, speed),
-        .acceleration = Vector2Create(0, 15),
+        .velocity = initialVelocity,
+        .acceleration = acceleration,
     }));
 
     ADD_COMPONENT(CSmooth, ((CSmooth)

--- a/src/ecs/entities/cloud_particle.h
+++ b/src/ecs/entities/cloud_particle.h
@@ -3,6 +3,12 @@
 #include "../../scene.h"
 #include "../entity_builder.h"
 
-EntityBuilder CloudParticleCreate(f32 centerX, f32 centerY, Vector2 direction);
+EntityBuilder CloudParticleCreate
+(
+    Vector2 position,
+    f32 radius,
+    Vector2 initialVelocity,
+    Vector2 acceleration
+);
 
 void CloudParticleDraw(const Scene* scene, usize entity);

--- a/src/ecs/entities/cloud_particle.h
+++ b/src/ecs/entities/cloud_particle.h
@@ -8,7 +8,8 @@ EntityBuilder CloudParticleCreate
     Vector2 position,
     f32 radius,
     Vector2 initialVelocity,
-    Vector2 acceleration
+    Vector2 acceleration,
+    f32 lifetime
 );
 
 void CloudParticleDraw(const Scene* scene, usize entity);

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -491,44 +491,6 @@ void PlayerInputUpdate(Scene* scene, const usize entity)
             player->grounded = false;
             player->jumping = true;
             kinetic->velocity.y = -jumpVelocity;
-
-            // Spawn cloud particles.
-            {
-                const Vector2 bottomCenter = (Vector2)
-                {
-                    .x = position->value.x + dimension->width * 0.5f,
-                    .y = position->value.y + dimension->height
-                };
-
-                Vector2 anchorOffset = VECTOR2_ZERO;
-
-                if (kinetic->velocity.x > 0)
-                {
-                    anchorOffset.x = -dimension->width * 0.5f;
-                }
-
-                if (kinetic->velocity.x < 0)
-                {
-                    anchorOffset.x = dimension->width * 0.5f;
-                }
-
-                const Vector2 anchor = Vector2Add(bottomCenter, anchorOffset);
-
-                Vector2 direction = Vector2Normalize(kinetic->velocity);
-                direction.x *= -1;
-
-                const EventCloudParticleParams params = (EventCloudParticleParams)
-                {
-                    .scene = scene,
-                    .entity = entity,
-                    .anchor = anchor,
-                    .direction = direction,
-                    .spawnCount = GetRandomValue(10, 25),
-                    .spread = dimension->width,
-                };
-
-                SpawnCloudParticles(&params);
-            }
         }
 
         // Variable Jump Height.

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -52,13 +52,15 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
 
     // Lateral pockets.
     {
-        const f32 angleIncrement = (DEG2RAD * 25) / spawnCount;
+        static const f32 theta = 25;
+        const f32 angleIncrement = (DEG2RAD * theta) / spawnCount;
 
         for (usize i = 0; i < spawnCount; ++i)
         {
             const f32 radius = GetRandomValue(1, 4);
             const f32 offset = GetRandomValue(0, spread);
             const f32 speed = GetRandomValue(10, 30);
+            const f32 lifetime = 1 + 0.5 * GetRandomValue(0, 4);
 
             // Left pocket.
             {
@@ -76,8 +78,9 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                 const Vector2 vo = Vector2Scale(direction, speed);
                 const Vector2 ao = (Vector2)
                 {
-                    .x = direction.x * -speed * 0.5,
-                    .y = direction.y * -speed * 0.5 + gravity,
+                    // a = (vf - vo) / t
+                    .x = (0 - vo.x) / lifetime,
+                    .y = gravity,
                 };
 
                 SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
@@ -99,8 +102,9 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                 const Vector2 vo = Vector2Scale(direction, speed);
                 const Vector2 ao = (Vector2)
                 {
-                    .x = direction.x * -speed * 0.5,
-                    .y = direction.y * -speed * 0.5 + gravity,
+                    // a = (vf - vo) / t
+                    .x = (0 - vo.x) / lifetime,
+                    .y = gravity,
                 };
 
                 SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
@@ -115,23 +119,27 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
 
     // Spawn extra cloud particles in the direction opposite of velocity.
     {
+        static const f32 reflection = 30;
+        static const f32 theta = 20;
+        const f32 anchorOffset = dimension->width * 0.25;
         const usize total = spawnCount * 0.5;
-        const f32 angleIncrement = (DEG2RAD * 20) / total;
+        const f32 angleIncrement = (DEG2RAD * theta) / total;
 
         for (usize i = 0; i < total; ++i)
         {
             const f32 radius = GetRandomValue(1, 3);
             const f32 offset = GetRandomValue(0, spread);
             const f32 speed = GetRandomValue(20, 35);
+            const f32 lifetime = 0.5 + 0.5 * GetRandomValue(0, 4);
 
             if (kinetic->velocity.x > 0)
             {
                 const Vector2 cloudPosition = (Vector2)
                 {
-                    .x = leftAnchor.x + dimension->width * 0.25 - offset - radius * 2,
+                    .x = leftAnchor.x + anchorOffset - offset - radius * 2,
                     .y = leftAnchor.y - radius * 2,
                 };
-                const f32 rotation = (DEG2RAD * (180 + 25)) + angleIncrement * i;
+                const f32 rotation = (DEG2RAD * (180 + reflection - theta * 0.5)) + angleIncrement * i;
                 const Vector2 direction = (Vector2)
                 {
                     .x = cosf(rotation),
@@ -140,8 +148,9 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                 const Vector2 vo = Vector2Scale(direction, speed);
                 const Vector2 ao = (Vector2)
                 {
-                    .x = direction.x * -speed * 0.5,
-                    .y = direction.y * -speed * 0.5 + gravity * 0.75,
+                    // a = (vf - vo) / t
+                    .x = (0 - vo.x) / lifetime,
+                    .y = gravity,
                 };
 
                 SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
@@ -150,10 +159,10 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
             {
                 const Vector2 cloudPosition = (Vector2)
                 {
-                    .x = rightAnchor.x - dimension->width * 0.25 + offset,
+                    .x = rightAnchor.x - anchorOffset + offset,
                     .y = rightAnchor.y - radius * 2,
                 };
-                const f32 rotation = (DEG2RAD * (0 - 25)) - angleIncrement * i;
+                const f32 rotation = (DEG2RAD * (0 - reflection + theta * 0.5)) - angleIncrement * i;
                 const Vector2 direction = (Vector2)
                 {
                     .x = cosf(rotation),
@@ -162,8 +171,9 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                 const Vector2 vo = Vector2Scale(direction, speed);
                 const Vector2 ao = (Vector2)
                 {
-                    .x = direction.x * -speed * 0.5,
-                    .y = direction.y * -speed * 0.5 + gravity * 0.75,
+                    // a = (vf - vo) / t
+                    .x = (0 - vo.x) / lifetime,
+                    .y = gravity,
                 };
 
                 SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
@@ -190,12 +200,14 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
 
     // Lateral pockets.
     {
-        const f32 angleIncrement = (DEG2RAD * 30) / spawnCount;
+        static const f32 theta = 30;
+        const f32 angleIncrement = (DEG2RAD * theta) / spawnCount;
 
         for (usize i = 0; i < spawnCount; ++i)
         {
             const f32 radius = GetRandomValue(1, 3);
-            const f32 speed = GetRandomValue(5, 20);
+            const f32 speed = GetRandomValue(10, 15);
+            const f32 lifetime = 0.5 + 0.5 * GetRandomValue(0, 3);
 
             // Left pocket.
             {
@@ -213,8 +225,9 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
                 const Vector2 vo = Vector2Scale(direction, speed);
                 const Vector2 ao = (Vector2)
                 {
-                    .x = direction.x * -speed * 0.5,
-                    .y = direction.y * -speed * 0.5 + gravity,
+                    // a = (vf - vo) / t
+                    .x = (0 - vo.x) / lifetime,
+                    .y = gravity,
                 };
 
                 SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
@@ -236,8 +249,9 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
                 const Vector2 vo = Vector2Scale(direction, speed);
                 const Vector2 ao = (Vector2)
                 {
-                    .x = direction.x * -speed * 0.5,
-                    .y = direction.y * -speed * 0.5 + gravity,
+                    // a = (vf - vo) / t
+                    .x = (0 - vo.x) / lifetime,
+                    .y = gravity,
                 };
 
                 SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
@@ -247,16 +261,33 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
 
     // Middle pocket.
     {
-        Vector2 direction = Vector2Normalize(kinetic->velocity);
-        direction.x *= -1;
-        const usize theta = 30;
-        const f32 angle = atan2f(direction.y, direction.x) - (DEG2RAD * theta * 0.5);
+        static const f32 reflection = 20;
+        static const f32 theta = 20;
+        static const f32 lateralMultiplier = 1.75;
+
+        const i8 sign = SIGN(kinetic->velocity.x);
+        f32 angle = -90;
+
+        if (sign < 0)
+        {
+            angle = -reflection;
+        }
+        else if (sign > 0)
+        {
+            angle = -180 + reflection;
+        }
+
+        angle -= theta * 0.5;
+        angle *= DEG2RAD;
+
         const usize total = spawnCount * 0.5;
         const f32 angleIncrement = (DEG2RAD * theta) / total;
 
         for (usize i = 0; i < total; ++i)
         {
             const f32 radius = GetRandomValue(2, 3);
+            const f32 lifetime = 0.5 + 0.5 * GetRandomValue(0, 4);
+
             const Vector2 cloudPosition = (Vector2)
             {
                 .x = anchor.x - radius,
@@ -273,14 +304,15 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
 
             if (kinetic->velocity.x != 0)
             {
-                speed *= 1.5;
+                speed *= lateralMultiplier;
             }
 
             const Vector2 vo = Vector2Scale(directionTmp, speed);
             const Vector2 ao = (Vector2)
             {
-                .x = direction.x * -speed * 0.5,
-                .y = direction.y * -speed * 0.5 + gravity * 5,
+                // a = (vf - vo) / t
+                .x = (0 - vo.x) / lifetime,
+                .y = gravity,
             };
 
             SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -83,7 +83,7 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                     .y = gravity,
                 };
 
-                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
+                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao, lifetime));
             }
 
             // Right pocket.
@@ -107,7 +107,7 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                     .y = gravity,
                 };
 
-                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
+                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao, lifetime));
             }
         }
     }
@@ -153,7 +153,7 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                     .y = gravity,
                 };
 
-                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
+                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao, lifetime));
             }
             else
             {
@@ -176,7 +176,7 @@ static void PlayerSpawnImpactParticles(Scene* scene, const usize entity, const f
                     .y = gravity,
                 };
 
-                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
+                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao, lifetime));
             }
         }
     }
@@ -230,7 +230,7 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
                     .y = gravity,
                 };
 
-                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
+                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao, lifetime));
             }
 
             // Right pocket.
@@ -254,7 +254,7 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
                     .y = gravity,
                 };
 
-                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
+                SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao, lifetime));
             }
         }
     }
@@ -315,7 +315,7 @@ static void PlayerSpawnJumpParticles(Scene* scene, const usize entity)
                 .y = gravity,
             };
 
-            SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao));
+            SceneDeferAddEntity(scene, CloudParticleCreate(cloudPosition, radius, vo, ao, lifetime));
         }
     }
 }

--- a/src/ecs/events.c
+++ b/src/ecs/events.c
@@ -29,21 +29,3 @@ void EventHandlerDestroy(EventHandler* self)
 {
     DequeDestroy(&self->listeners);
 }
-
-// TODO(thismarvin): Is this too specialized?
-void SpawnCloudParticles(const EventCloudParticleParams* params)
-{
-    for (usize i = 0; i < params->spawnCount; ++i)
-    {
-        const Vector2 spreadOffset = (Vector2)
-        {
-            .x = (f32)GetRandomValue(-params->spread, params->spread),
-            .y = 0,
-        };
-        const Vector2 center = Vector2Add(params->anchor, spreadOffset);
-        const f32 rotation = (f32)GetRandomValue(DEG2RAD * -45, DEG2RAD * 45);
-        const Vector2 direction = Vector2Rotate(params->direction, rotation);
-
-        SceneDeferAddEntity(params->scene, CloudParticleCreate(center.x, center.y, direction));
-    }
-}

--- a/src/ecs/events.h
+++ b/src/ecs/events.h
@@ -14,17 +14,3 @@ EventHandler EventHandlerCreate(void);
 void EventHandlerSubscribe(EventHandler* self, OnRaise onRaise);
 void EventHandlerRaise(const EventHandler* self, const void* arguments);
 void EventHandlerDestroy(EventHandler* self);
-
-typedef struct Scene Scene;
-
-typedef struct
-{
-    Scene* scene;
-    usize entity;
-    Vector2 anchor;
-    Vector2 direction;
-    usize spawnCount;
-    usize spread;
-} EventCloudParticleParams;
-
-void SpawnCloudParticles(const EventCloudParticleParams* params);

--- a/src/ecs/systems.c
+++ b/src/ecs/systems.c
@@ -63,21 +63,6 @@ void SKineticUpdate(Scene* scene, const usize entity)
     position->value.y += kinetic->velocity.y * CTX_DT;
 }
 
-static i8 sign(const f32 value)
-{
-    if (value < 0)
-    {
-        return -1;
-    }
-
-    if (value > 0)
-    {
-        return 1;
-    }
-
-    return 0;
-}
-
 // TODO(thismarvin): This following static collision stuff needs a better home...
 
 static Vector2 ExtractResolution(const Vector2 resolution, const u64 layers)
@@ -117,7 +102,7 @@ static SimulateCollisionOnAxisResult SimulateCollisionOnAxis
 
     Rectangle simulatedAabb = params->aabb;
 
-    Vector2 direction = Vector2Create(sign(params->delta.x), sign(params->delta.y));
+    Vector2 direction = Vector2Create(SIGN(params->delta.x), SIGN(params->delta.y));
     Vector2 remainder = Vector2Create(fabsf(params->delta.x), fabsf(params->delta.y));
 
     bool xModified = false;


### PR DESCRIPTION
`CloudParticle`'s implementation is awkward:

- Why is it still related to events?
- Why is its setup so restrictive?

The following changes address said issues.

Also, I reimplemented the Player's use of cloud particles when jumping to look cooler (IMO) and added impact particles when colliding with the top of a collider.