### PR TITLE
Clean up `flake.nix`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,6 @@
 					astyle
 					nodePackages.prettier
 					emscripten
-					ccls
 				];
 			};
 		};


### PR DESCRIPTION
I just found out that you can nest calls to `nix develop`; I no longer need to force other users to use my preferred tooling!

Moving forward, `flake.nix` will always have the bare minimum.