### PR TITLE
Always draw Debug information last.

### DIFF
--- a/src/scene.c
+++ b/src/scene.c
@@ -416,6 +416,7 @@ static void SceneSetupLayers(Scene* self)
     self->backgroundLayer = LoadRenderTexture(CTX_VIEWPORT_WIDTH, CTX_VIEWPORT_HEIGHT);
     self->targetLayer = LoadRenderTexture(CTX_VIEWPORT_WIDTH * zoom, CTX_VIEWPORT_HEIGHT * zoom);
     self->foregroundLayer = LoadRenderTexture(CTX_VIEWPORT_WIDTH, CTX_VIEWPORT_HEIGHT);
+    self->debugLayer = LoadRenderTexture(CTX_VIEWPORT_WIDTH * zoom, CTX_VIEWPORT_HEIGHT * zoom);
 }
 
 static void SceneSetupLevelSegments(Scene* self)
@@ -776,6 +777,15 @@ static void SceneDrawLayers(const Scene* self)
         DrawTexturePro(self->foregroundLayer.texture, source, destination, origin, 0, WHITE);
     }
 
+    // Draw debug layer.
+    if (self->debugging)
+    {
+        Rectangle source = RectangleFromRenderTexture(self->debugLayer);
+        source.height *= -1;
+
+        DrawTexturePro(self->debugLayer.texture, source, destination, origin, 0, WHITE);
+    }
+
     EndDrawing();
 }
 
@@ -825,6 +835,16 @@ static void RenderForegroundLayer(const RenderFnParams* params)
     }
 }
 
+static void RenderDebugLayer(const RenderFnParams* params)
+{
+    if (!params->scene->debugging)
+    {
+        return;
+    }
+
+    ClearBackground(COLOR_TRANSPARENT);
+}
+
 void SceneDraw(const Scene* self)
 {
     Rectangle actionCameraBounds = SceneCalculateActionCameraBounds(self, self->player);
@@ -839,6 +859,7 @@ void SceneDraw(const Scene* self)
     SceneRenderLayer(&self->backgroundLayer, RenderBackgroundLayer, &params);
     SceneRenderLayer(&self->targetLayer, RenderTargetLayer, &params);
     SceneRenderLayer(&self->foregroundLayer, RenderForegroundLayer, &params);
+    SceneRenderLayer(&self->debugLayer, RenderDebugLayer, &params);
 
     SceneDrawLayers(self);
 }
@@ -863,4 +884,5 @@ void SceneDestroy(Scene* self)
     UnloadRenderTexture(self->backgroundLayer);
     UnloadRenderTexture(self->targetLayer);
     UnloadRenderTexture(self->foregroundLayer);
+    UnloadRenderTexture(self->debugLayer);
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -811,11 +811,6 @@ static void RenderTargetLayer(const RenderFnParams* params)
     {
         SSpriteDraw(params->scene, i);
         SAnimationDraw(params->scene, i);
-
-        if (params->scene->debugging)
-        {
-            SDebugDraw(params->scene, i);
-        }
     }
 }
 
@@ -843,6 +838,11 @@ static void RenderDebugLayer(const RenderFnParams* params)
     }
 
     ClearBackground(COLOR_TRANSPARENT);
+
+    for (usize i = 0; i < SceneGetEntityCount(params->scene); ++i)
+    {
+        SDebugDraw(params->scene, i);
+    }
 }
 
 void SceneDraw(const Scene* self)

--- a/src/scene.h
+++ b/src/scene.h
@@ -55,6 +55,7 @@ struct Scene
     RenderTexture2D backgroundLayer;
     RenderTexture2D targetLayer;
     RenderTexture2D foregroundLayer;
+    RenderTexture2D debugLayer;
     // TODO(thismarvin): Should this exist in Scene?
     InputHandler input;
     Deque commands;


### PR DESCRIPTION
If we are in debug mode, it does not make sense for other entities to be drawn over any debug information.