### PR TITLE
Move `$(VERBOSE).SILENT` after `@all`

### DIFF
--- a/vendor/cJSON/Makefile.Bootstrap
+++ b/vendor/cJSON/Makefile.Bootstrap
@@ -2,10 +2,10 @@ GIT ?= git
 
 TAG := v1.7.15
 
-$(VERBOSE).SILENT:
-
 .PHONY: @all
 @all: @clean @cJSON
+
+$(VERBOSE).SILENT:
 
 src:
 	mkdir $@

--- a/vendor/cJSON/Makefile.Desktop
+++ b/vendor/cJSON/Makefile.Desktop
@@ -4,10 +4,10 @@ AR ?= ar
 DESTDIR ?= .
 CFLAGS := -std=c89 -O1
 
-$(VERBOSE).SILENT:
-
 OBJECTS := \
 	$(DESTDIR)/lib/desktop/cJSON/cJSON.o
+
+$(VERBOSE).SILENT:
 
 .PHONY: @all
 @all: @clean @lib

--- a/vendor/cJSON/Makefile.Web
+++ b/vendor/cJSON/Makefile.Web
@@ -4,13 +4,13 @@ EMAR ?= emar
 DESTDIR ?= .
 CFLAGS := -std=c89 -O1
 
-$(VERBOSE).SILENT:
-
 OBJECTS := \
 	$(DESTDIR)/lib/web/cJSON/cJSON.o
 
 .PHONY: @all
 @all: @clean @lib
+
+$(VERBOSE).SILENT:
 
 $(DESTDIR)/lib:
 	mkdir $@

--- a/vendor/raylib/Makefile.Bootstrap
+++ b/vendor/raylib/Makefile.Bootstrap
@@ -3,10 +3,10 @@ NU ?= nu
 
 TAG := 4.2.0
 
-$(VERBOSE).SILENT:
-
 .PHONY: @all
 @all: @clean @raylib
+
+$(VERBOSE).SILENT:
 
 src/raylib.h:
 	$(GIT) clone --depth 1 --branch $(TAG) https://github.com/raysan5/raylib

--- a/vendor/raylib/Makefile.Desktop
+++ b/vendor/raylib/Makefile.Desktop
@@ -5,8 +5,6 @@ DESTDIR ?= .
 cflags.vendor := $(shell pkg-config --cflags x11 xcursor xext xfixes xi xinerama xrandr xrender)
 CFLAGS := -std=c99 -D_DEFAULT_SOURCE -fPIC -s -O1 -DPLATFORM_DESKTOP -DGRAPHICS_API_OPENGL_33 -Isrc -Isrc/external/glfw/include $(cflags.vendor)
 
-$(VERBOSE).SILENT:
-
 OBJECTS := \
 	$(DESTDIR)/lib/desktop/raylib/raudio.o \
 	$(DESTDIR)/lib/desktop/raylib/rcore.o \
@@ -19,6 +17,8 @@ OBJECTS := \
 
 .PHONY: @all
 @all: @clean @lib
+
+$(VERBOSE).SILENT:
 
 $(DESTDIR)/lib:
 	mkdir $@

--- a/vendor/raylib/Makefile.Web
+++ b/vendor/raylib/Makefile.Web
@@ -4,8 +4,6 @@ EMAR ?= emar
 DESTDIR ?= .
 CFLAGS := -O1 -DPLATFORM_WEB -DGRAPHICS_API_OPENGL_ES2
 
-$(VERBOSE).SILENT:
-
 OBJECTS := \
 	$(DESTDIR)/lib/web/raylib/raudio.o \
 	$(DESTDIR)/lib/web/raylib/rcore.o \
@@ -17,6 +15,8 @@ OBJECTS := \
 
 .PHONY: @all
 @all: @clean @lib
+
+$(VERBOSE).SILENT:
 
 $(DESTDIR)/lib:
 	mkdir $@


### PR DESCRIPTION
For some reason `$(VERBOSE).SILENT` becomes the default goal when using `export VERBOSE=1`? I am not really sure why, but simply moving it after `@all` seems to work.