### PR TITLE
Nix Maintenance (2022-11-14)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667849450,
-        "narHash": "sha256-kAKio7o9zbozgsw8LQJsZX7ocNbvzo9HJM3XtAM+WoE=",
+        "lastModified": 1668443372,
+        "narHash": "sha256-lXNlVyNWwO22/JUdBtUWz68jZB3DM+Jq/irlsbwncI0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52f9de5b39a22c86899d6e35c68ac7fab42dbb98",
+        "rev": "dad4de1694cd92d9a0e123bfdf134d0047b836a5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   outputs = { self, nixpkgs }:
     let
       pname = "ltlr";
-      version = "2022-11-07";
+      version = "2022-11-14";
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
     in


### PR DESCRIPTION
I've ran `nix flake update` and made sure everything (i.e. `make @dev`, `make @web`, and `nix run`) works.

I'm not really sure when / how often you should run `nix flake update` — does `nix run github:delveam/ltlr` use the latest version or the latest commit? — but I mean if it works it works...