### PR TITLE
 Nix Maintenance (2022-11-22)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1668443372,
-        "narHash": "sha256-lXNlVyNWwO22/JUdBtUWz68jZB3DM+Jq/irlsbwncI0=",
+        "lastModified": 1669052613,
+        "narHash": "sha256-u6+SfRhx4L1p+H0/5dL2zprVDHzQ2DJ1d5ncd0Fd1WI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dad4de1694cd92d9a0e123bfdf134d0047b836a5",
+        "rev": "debe1b93c9ec3651fbb57060468b9f78873468c8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   outputs = { self, nixpkgs }:
     let
       pname = "ltlr";
-      version = "2022-11-14";
+      version = "2022-11-21";
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
     in


### PR DESCRIPTION
Just another `nix flake update` and version bump. `make @dev`, `make @web`, and `nix run` work (for real this time).

Overall, this project is somewhat on pause (i.e. there hasn't been any new features in a while), but I still wanted to keep up this nix maintenance thing going! 