### PR TITLE
Extract some functions from `Scene`

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -1,12 +1,39 @@
 #include "context.h"
+#include <raymath.h>
 
-static f64 totalTime = 0.0;
-static f32 alpha = 0.0;
+static f64 totalTime;
+static f32 alpha;
 
-// f32 ContextGetDeltaTime(void)
-// {
-//     return CTX_DT;
-// }
+static Rectangle monitorResolution;
+
+void ContextInit(void)
+{
+    totalTime = 0.0;
+    alpha = 0.0;
+
+    // Calculate the monitor's resolution.
+    {
+        const int currentMonitor = GetCurrentMonitor();
+
+        int width = GetMonitorWidth(currentMonitor);
+        int height = GetMonitorHeight(currentMonitor);
+
+        // For every platform except desktop, the following is always true
+        if (width == 0 || height == 0)
+        {
+            width = DEFAULT_WINDOW_WIDTH;
+            height = DEFAULT_WINDOW_HEIGHT;
+        }
+
+        monitorResolution = (Rectangle)
+        {
+            .x = 0,
+            .y = 0,
+            .width = width,
+            .height = height,
+        };
+    }
+}
 
 f64 ContextGetTotalTime(void)
 {
@@ -26,4 +53,128 @@ f32 ContextGetAlpha(void)
 void ContextSetAlpha(const f32 value)
 {
     alpha = value;
+}
+
+Rectangle GetMonitorResolution()
+{
+    return monitorResolution;
+}
+
+Rectangle GetScreenResolution()
+{
+    return (Rectangle)
+    {
+        .x = 0,
+        .y = 0,
+        .width = GetScreenWidth(),
+        .height = GetScreenHeight(),
+    };
+}
+
+Rectangle RectangleFromRenderTexture(const RenderTexture* renderTexture)
+{
+    return (Rectangle)
+    {
+        .x = 0,
+        .y = 0,
+        .width = renderTexture->texture.width,
+        .height = renderTexture->texture.height,
+    };
+}
+
+// Returns the maximum value the dimensions of a given region can be multiplied by and still fit
+// within a given container.
+f32 CalculateZoom(const Rectangle region, const Rectangle container)
+{
+    // Assume we need letterboxing.
+    f32 zoom = container.width / region.width;
+
+    // Check if pillarboxing is more appropriate.
+    if (region.height * zoom > container.height)
+    {
+        zoom = container.height / region.height;
+    }
+
+    return zoom;
+}
+
+void RenderLayer
+(
+    const RenderTexture* renderTexture,
+    const RenderFn fn,
+    const RenderFnParams* params
+)
+{
+    const Rectangle bounds = RectangleFromRenderTexture(renderTexture);
+    const f32 zoom = CalculateZoom(CTX_VIEWPORT, bounds);
+
+    const Vector2 cameraCenter = (Vector2)
+    {
+        .x = params->cameraBounds.x + CTX_VIEWPORT_WIDTH * 0.5,
+        .y = params->cameraBounds.y + CTX_VIEWPORT_HEIGHT * 0.5,
+    };
+
+    const Camera2D camera = (Camera2D)
+    {
+        .zoom = zoom,
+        .offset = Vector2Scale(cameraCenter, -zoom),
+        .target = (Vector2)
+        {
+            .x = -CTX_VIEWPORT_WIDTH * 0.5,
+            .y = -CTX_VIEWPORT_HEIGHT * 0.5,
+        },
+        .rotation = 0,
+    };
+
+    BeginTextureMode(*renderTexture);
+    BeginMode2D(camera);
+    {
+        fn(params);
+    }
+    EndMode2D();
+    EndTextureMode();
+}
+
+void DrawLayers(const RenderTexture* renderTextures, const usize renderTexturesLength)
+{
+    const Rectangle screenResolution = GetScreenResolution();
+
+    f32 zoom = CalculateZoom(CTX_VIEWPORT, screenResolution);
+
+    // TODO(thismarvin): Expose "preferIntegerScaling" option.
+    // Prefer integer scaling.
+    zoom = floor(zoom);
+
+    const i32 width = CTX_VIEWPORT_WIDTH * zoom;
+    const i32 height = CTX_VIEWPORT_HEIGHT * zoom;
+
+    const Rectangle destination = (Rectangle)
+    {
+        .x = floor(screenResolution.width * 0.5),
+        .y = floor(screenResolution.height * 0.5),
+        .width = width,
+        .height = height,
+    };
+
+    const Vector2 origin = (Vector2)
+    {
+        .x = floor(width * 0.5),
+        .y = floor(height * 0.5),
+    };
+
+    BeginDrawing();
+    {
+        ClearBackground(COLOR_BLACK);
+
+        for (usize i = 0; i < renderTexturesLength; ++i)
+        {
+            const RenderTexture* renderTexture = &renderTextures[i];
+
+            Rectangle source = RectangleFromRenderTexture(renderTexture);
+            source.height *= -1;
+
+            DrawTexturePro(renderTexture->texture, source, destination, origin, 0, WHITE);
+        }
+    }
+    EndDrawing();
 }

--- a/src/context.h
+++ b/src/context.h
@@ -2,17 +2,41 @@
 
 #include "common.h"
 
-#define CTX_VIEWPORT_WIDTH 320
-#define CTX_VIEWPORT_HEIGHT 180
+#define CTX_VIEWPORT_WIDTH (320)
+#define CTX_VIEWPORT_HEIGHT (180)
 
-#define DEFAULT_WINDOW_WIDTH CTX_VIEWPORT_WIDTH * 3
-#define DEFAULT_WINDOW_HEIGHT CTX_VIEWPORT_HEIGHT * 3
+#define CTX_VIEWPORT ((Rectangle) { 0, 0, CTX_VIEWPORT_WIDTH, CTX_VIEWPORT_HEIGHT })
+
+#define DEFAULT_WINDOW_WIDTH (CTX_VIEWPORT_WIDTH * 3)
+#define DEFAULT_WINDOW_HEIGHT (CTX_VIEWPORT_HEIGHT * 3)
 
 // Target (fixed) delta time.
 #define CTX_DT (1.0 / 60.0)
 
-// f32 ContextGetDeltaTime(void);
+typedef struct
+{
+    void* scene;
+    Rectangle cameraBounds;
+} RenderFnParams;
+
+typedef void (*RenderFn)(const RenderFnParams*);
+
+void ContextInit(void);
 f64 ContextGetTotalTime(void);
 void ContextSetTotalTime(f64 value);
 f32 ContextGetAlpha(void);
 void ContextSetAlpha(f32 value);
+
+Rectangle GetMonitorResolution(void);
+Rectangle GetScreenResolution(void);
+
+Rectangle RectangleFromRenderTexture(const RenderTexture* renderTexture);
+f32 CalculateZoom(Rectangle region, Rectangle container);
+
+void RenderLayer
+(
+    const RenderTexture* renderTexture,
+    const RenderFn fn,
+    const RenderFnParams* params
+);
+void DrawLayers(const RenderTexture* renderTextures, usize renderTexturesLength);

--- a/src/game.c
+++ b/src/game.c
@@ -108,6 +108,8 @@ int main(void)
 
 static void Initialize(void)
 {
+    ContextInit();
+
     SceneInit(&scene);
 }
 

--- a/src/scene.h
+++ b/src/scene.h
@@ -48,7 +48,6 @@ struct Scene
     Rectangle bounds;
     Atlas atlas;
     Level level;
-    Rectangle trueResolution;
     Rectangle renderResolution;
     RenderTexture2D rootLayer;
     RenderTexture2D backgroundLayer;


### PR DESCRIPTION
In an attempt to make `Scene` slightly more modular, I decided to extract a couple useful functions from `Scene` and stick them in `context.h`. I wouldn't say `context.h` is the best home for said functions, but I thought it at least made some sense considering `CTX_VIEWPORT` stuff already lives there.

I really should have broken this commit up some more, but I didn't :+1: 