### PR TITLE
Nix Maintenance (2023-01-09)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672686111,
-        "narHash": "sha256-7otTe3dIGdqBiK9f6LEi+fgWUbIxMLd06phv1NyNb8I=",
+        "lastModified": 1673180965,
+        "narHash": "sha256-gMhL6w9RVluvPs+irJ9n0Q1BphZm+Ek4XGn5Ow7YQ3k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9f5839a6ea0e62a85c8ed35eb6b665fe778c3b4a",
+        "rev": "0c9aadc8eff6daaa5149d2df9e6c49baaf44161c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "a 2D action platformer";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
   outputs = { self, nixpkgs }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
   outputs = { self, nixpkgs }:
     let
       pname = "ltlr";
-      version = "2023-01-02";
+      version = "2023-01-09";
       system = "x86_64-linux";
       pkgs = import nixpkgs { inherit system; };
     in


### PR DESCRIPTION
Our flake now uses `nixpkgs-unstable` branch instead of `master`.

`make @dev`, `make @web`, and `nix run .` all seem to work. I also made sure to also test adding a new file, building, removing said file, and building again.

I'd say there was a decent amount of progress this week!