### PR TITLE
Revisting `CPlayer`

### DIFF
--- a/src/ecs/components.h
+++ b/src/ecs/components.h
@@ -189,26 +189,30 @@ typedef struct
 	f32 age;
 } CFleeting;
 
-// TODO(thismarvin): Should this be in some sort of Singleton?
 typedef struct
 {
+	u8 handle;
+} CPlayer;
+
+typedef struct
+{
+	Vector2 gravityForce;
 	bool groundedLastFrame;
 	bool grounded;
 	bool jumping;
-	bool dead;
 	f32 coyoteTimer;
+	bool dead;
 	f32 invulnerableTimer;
 	f32 sprintTimer;
 	f32 sprintDuration;
 	Direction initialDirection;
 	Direction sprintDirection;
 	PlayerSprintState sprintState;
-	PlayerAnimationState animationState;
-	Vector2 gravityForce;
 	Vector2 sprintForce;
+	PlayerAnimationState animationState;
+	f32 stompTimer;
+	PlayerStompState stompState;
 	Vector2 stompForce;
 	f32 trailTimer;
-	PlayerStompState stompState;
-	f32 stompTimer;
 	f32 velocityLastFrame;
-} CPlayer;
+} Player;

--- a/src/ecs/entities/player.c
+++ b/src/ecs/entities/player.c
@@ -942,7 +942,7 @@ void PlayerStompLogic(Scene* scene, CPlayer* player, CKinetic* kinetic)
 
 				f32 maxVelocity = -jumpVelocity;
 
-				if (InputHandlerPressing(&scene->input, "jump"))
+				if (InputHandlerPressing(&scene->input, "stomp"))
 				{
 					maxVelocity *= 1.5;
 				}

--- a/src/ecs/entities/player.h
+++ b/src/ecs/entities/player.h
@@ -7,6 +7,7 @@
 typedef struct
 {
 	usize entity;
+	u8 handle;
 	f32 x;
 	f32 y;
 } PlayerBuilder;

--- a/src/input.c
+++ b/src/input.c
@@ -563,9 +563,12 @@ void InputHandlerUpdate(InputHandler* self)
 		return;
 	}
 
-	for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
+	if (self->m_gamepad == 0)
 	{
-		KeyboardBindingUpdate(&self->m_profile->m_keyboardBindings[i]);
+		for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
+		{
+			KeyboardBindingUpdate(&self->m_profile->m_keyboardBindings[i]);
+		}
 	}
 
 	for (usize i = 0; i < self->m_profile->m_gamepadBindingsLength; ++i)
@@ -586,13 +589,16 @@ bool InputHandlerPressed(const InputHandler* self, const char* binding)
 		return false;
 	}
 
-	for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
+	if (self->m_gamepad == 0)
 	{
-		if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
+		for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
 		{
-			if (KeyboardBindingPressed(&self->m_profile->m_keyboardBindings[i]))
+			if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
 			{
-				return true;
+				if (KeyboardBindingPressed(&self->m_profile->m_keyboardBindings[i]))
+				{
+					return true;
+				}
 			}
 		}
 	}
@@ -629,13 +635,16 @@ bool InputHandlerPressing(const InputHandler* self, const char* binding)
 		return false;
 	}
 
-	for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
+	if (self->m_gamepad == 0)
 	{
-		if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
+		for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
 		{
-			if (KeyboardBindingPressing(&self->m_profile->m_keyboardBindings[i]))
+			if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
 			{
-				return true;
+				if (KeyboardBindingPressing(&self->m_profile->m_keyboardBindings[i]))
+				{
+					return true;
+				}
 			}
 		}
 	}
@@ -683,13 +692,16 @@ bool InputHandlerReleased(const InputHandler* self, const char* binding)
 		return false;
 	}
 
-	for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
+	if (self->m_gamepad == 0)
 	{
-		if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
+		for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
 		{
-			if (KeyboardBindingReleased(&self->m_profile->m_keyboardBindings[i]))
+			if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
 			{
-				return true;
+				if (KeyboardBindingReleased(&self->m_profile->m_keyboardBindings[i]))
+				{
+					return true;
+				}
 			}
 		}
 	}
@@ -726,13 +738,16 @@ void InputHandlerConsume(InputHandler* self, const char* binding)
 		return;
 	}
 
-	for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
+	if (self->m_gamepad == 0)
 	{
-		if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
+		for (usize i = 0; i < self->m_profile->m_keyboardBindingsLength; ++i)
 		{
-			KeyboardBindingConsume(&self->m_profile->m_keyboardBindings[i]);
+			if (strcmp(self->m_profile->m_keyboardBindings[i].m_name, binding) == 0)
+			{
+				KeyboardBindingConsume(&self->m_profile->m_keyboardBindings[i]);
 
-			break;
+				break;
+			}
 		}
 	}
 

--- a/src/scene.c
+++ b/src/scene.c
@@ -170,112 +170,9 @@ static void SceneSetupContent(Scene* self)
 }
 
 // clang-format off
-static void SceneSetupActionProfile(Scene* self)
+static InputProfile CreateDefaultMenuProfile(void)
 {
-	self->defaultActionProfile = InputProfileCreate(4);
-
-	// Keyboard.
-	{
-		{
-			KeyboardBinding binding = KeyboardBindingCreate("left", 2);
-
-			KeyboardBindingAddKey(&binding, KEY_LEFT);
-			KeyboardBindingAddKey(&binding, KEY_A);
-
-			InputProfileAddKeyboardBinding(&self->defaultActionProfile, binding);
-		}
-		{
-			KeyboardBinding binding = KeyboardBindingCreate("right", 2);
-
-			KeyboardBindingAddKey(&binding, KEY_RIGHT);
-			KeyboardBindingAddKey(&binding, KEY_D);
-
-			InputProfileAddKeyboardBinding(&self->defaultActionProfile, binding);
-		}
-		{
-			KeyboardBinding binding = KeyboardBindingCreate("stomp", 2);
-
-			KeyboardBindingAddKey(&binding, KEY_X);
-			KeyboardBindingAddKey(&binding, KEY_J);
-
-			InputProfileAddKeyboardBinding(&self->defaultActionProfile, binding);
-		}
-		{
-			KeyboardBinding binding = KeyboardBindingCreate("jump", 2);
-
-			KeyboardBindingAddKey(&binding, KEY_Z);
-			KeyboardBindingAddKey(&binding, KEY_SPACE);
-
-			KeyboardBindingSetBuffer(&binding, CTX_DT * 8);
-
-			InputProfileAddKeyboardBinding(&self->defaultActionProfile, binding);
-		}
-	}
-
-	// Gamepad.
-	{
-		// Buttons.
-		{
-			{
-				GamepadBinding binding = GamepadBindingCreate("left", 1);
-
-				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_LEFT_FACE_LEFT);
-
-				InputProfileAddGamepadBinding(&self->defaultActionProfile, binding);
-			}
-			{
-				GamepadBinding binding = GamepadBindingCreate("right", 1);
-
-				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_LEFT_FACE_RIGHT);
-
-				InputProfileAddGamepadBinding(&self->defaultActionProfile, binding);
-			}
-			{
-				GamepadBinding binding = GamepadBindingCreate("stomp", 2);
-
-				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_LEFT);
-				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_RIGHT);
-
-				InputProfileAddGamepadBinding(&self->defaultActionProfile, binding);
-			}
-			{
-				GamepadBinding binding = GamepadBindingCreate("jump", 2);
-
-				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_DOWN);
-				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_UP);
-
-				GamepadBindingSetBuffer(&binding, CTX_DT * 8);
-
-				InputProfileAddGamepadBinding(&self->defaultActionProfile, binding);
-			}
-		}
-
-		// Axes.
-		{
-			static const f32 threshold = 0.25f;
-			{
-				AxisBinding binding = AxisBindingCreate("left", 2, ORD_LESS, -threshold);
-
-				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_LEFT_X);
-				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_RIGHT_X);
-
-				InputProfileAddAxisBinding(&self->defaultActionProfile, binding);
-			}
-			{
-				AxisBinding binding = AxisBindingCreate("right", 2, ORD_GREATER, threshold);
-
-				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_LEFT_X);
-				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_RIGHT_X);
-
-				InputProfileAddAxisBinding(&self->defaultActionProfile, binding);
-			}
-		}
-	}
-}
-
-static void SceneSetupMenuProfile(Scene* self)
-{
-	self->defaultMenuProfile = InputProfileCreate(1);
+	InputProfile profile = InputProfileCreate(1);
 
 	// Keyboard.
 	{
@@ -285,7 +182,7 @@ static void SceneSetupMenuProfile(Scene* self)
 			KeyboardBindingAddKey(&binding, KEY_SPACE);
 			KeyboardBindingAddKey(&binding, KEY_ENTER);
 
-			InputProfileAddKeyboardBinding(&self->defaultMenuProfile, binding);
+			InputProfileAddKeyboardBinding(&profile, binding);
 		}
 	}
 
@@ -299,22 +196,135 @@ static void SceneSetupMenuProfile(Scene* self)
 				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_MIDDLE_LEFT);
 				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_MIDDLE_RIGHT);
 
-				InputProfileAddGamepadBinding(&self->defaultMenuProfile, binding);
+				InputProfileAddGamepadBinding(&profile, binding);
 			}
 		}
 	}
+
+	return profile;
+}
+
+// clang-format on
+
+// clang-format off
+static InputProfile CreateDefaultActionProfile(void)
+{
+	InputProfile profile = InputProfileCreate(4);
+
+	// Keyboard.
+	{
+		{
+			KeyboardBinding binding = KeyboardBindingCreate("left", 2);
+
+			KeyboardBindingAddKey(&binding, KEY_LEFT);
+			KeyboardBindingAddKey(&binding, KEY_A);
+
+			InputProfileAddKeyboardBinding(&profile, binding);
+		}
+		{
+			KeyboardBinding binding = KeyboardBindingCreate("right", 2);
+
+			KeyboardBindingAddKey(&binding, KEY_RIGHT);
+			KeyboardBindingAddKey(&binding, KEY_D);
+
+			InputProfileAddKeyboardBinding(&profile, binding);
+		}
+		{
+			KeyboardBinding binding = KeyboardBindingCreate("stomp", 2);
+
+			KeyboardBindingAddKey(&binding, KEY_X);
+			KeyboardBindingAddKey(&binding, KEY_J);
+
+			InputProfileAddKeyboardBinding(&profile, binding);
+		}
+		{
+			KeyboardBinding binding = KeyboardBindingCreate("jump", 2);
+
+			KeyboardBindingAddKey(&binding, KEY_Z);
+			KeyboardBindingAddKey(&binding, KEY_SPACE);
+
+			KeyboardBindingSetBuffer(&binding, CTX_DT * 8);
+
+			InputProfileAddKeyboardBinding(&profile, binding);
+		}
+	}
+
+	// Gamepad.
+	{
+		// Buttons.
+		{
+			{
+				GamepadBinding binding = GamepadBindingCreate("left", 1);
+
+				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_LEFT_FACE_LEFT);
+
+				InputProfileAddGamepadBinding(&profile, binding);
+			}
+			{
+				GamepadBinding binding = GamepadBindingCreate("right", 1);
+
+				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_LEFT_FACE_RIGHT);
+
+				InputProfileAddGamepadBinding(&profile, binding);
+			}
+			{
+				GamepadBinding binding = GamepadBindingCreate("stomp", 2);
+
+				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_LEFT);
+				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_RIGHT);
+
+				InputProfileAddGamepadBinding(&profile, binding);
+			}
+			{
+				GamepadBinding binding = GamepadBindingCreate("jump", 2);
+
+				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_DOWN);
+				GamepadBindingAddButton(&binding, GAMEPAD_BUTTON_RIGHT_FACE_UP);
+
+				GamepadBindingSetBuffer(&binding, CTX_DT * 8);
+
+				InputProfileAddGamepadBinding(&profile, binding);
+			}
+		}
+
+		// Axes.
+		{
+			static const f32 threshold = 0.25f;
+			{
+				AxisBinding binding = AxisBindingCreate("left", 2, ORD_LESS, -threshold);
+
+				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_LEFT_X);
+				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_RIGHT_X);
+
+				InputProfileAddAxisBinding(&profile, binding);
+			}
+			{
+				AxisBinding binding = AxisBindingCreate("right", 2, ORD_GREATER, threshold);
+
+				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_LEFT_X);
+				AxisBindingAddAxis(&binding, GAMEPAD_AXIS_RIGHT_X);
+
+				InputProfileAddAxisBinding(&profile, binding);
+			}
+		}
+	}
+
+	return profile;
 }
 
 // clang-format on
 
 static void SceneSetupInput(Scene* self)
 {
-	self->input = InputHandlerCreate(0);
+	for (usize i = 0; i < MAX_PLAYERS; ++i)
+	{
+		self->inputs[i] = InputHandlerCreate(i);
 
-	SceneSetupMenuProfile(self);
-	SceneSetupActionProfile(self);
+		self->menuProfiles[i] = CreateDefaultMenuProfile();
+		self->actionProfiles[i] = CreateDefaultActionProfile();
 
-	InputHandlerSetProfile(&self->input, &self->defaultMenuProfile);
+		InputHandlerSetProfile(&self->inputs[i], &self->menuProfiles[i]);
+	}
 }
 
 static RenderTexture GenerateTreeTexture(void)
@@ -760,13 +770,18 @@ static void SceneCheckEndCondition(Scene* self)
 
 static void SceneMenuUpdate(Scene* self)
 {
-	if (InputHandlerPressed(&self->input, "select"))
+	// Only give player one control in the menu state.
+	if (InputHandlerPressed(&self->inputs[0], "select"))
 	{
-		InputHandlerConsume(&self->input, "select");
+		InputHandlerConsume(&self->inputs[0], "select");
 
 		// TODO(thismarvin): Defer this somehow...
 		self->state = SCENE_STATE_ACTION;
-		InputHandlerSetProfile(&self->input, &self->defaultActionProfile);
+
+		for (usize i = 0; i < MAX_PLAYERS; ++i)
+		{
+			InputHandlerSetProfile(&self->inputs[i], &self->actionProfiles[i]);
+		}
 
 		// TODO(thismarvin): There should be a bespoke transition into the Action state.
 		self->fader.easer.duration = CTX_DT * 40;
@@ -881,7 +896,10 @@ static void SceneActionUpdate(Scene* self)
 
 void SceneUpdate(Scene* self)
 {
-	InputHandlerUpdate(&self->input);
+	for (usize i = 0; i < MAX_PLAYERS; ++i)
+	{
+		InputHandlerUpdate(&self->inputs[i]);
+	}
 
 	if (IsKeyPressed(KEY_EQUAL))
 	{
@@ -1337,6 +1355,9 @@ void SceneDestroy(Scene* self)
 	UnloadRenderTexture(self->transitionLayer);
 	UnloadRenderTexture(self->debugLayer);
 
-	InputProfileDestroy(&self->defaultMenuProfile);
-	InputProfileDestroy(&self->defaultActionProfile);
+	for (usize i = 0; i < MAX_PLAYERS; ++i)
+	{
+		InputProfileDestroy(&self->menuProfiles[i]);
+		InputProfileDestroy(&self->actionProfiles[i]);
+	}
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -522,6 +522,7 @@ static void ScenePopulateLevel(Scene* self)
 		self->player = SceneAllocateEntity(self);
 		PlayerBuilder* builder = malloc(sizeof(PlayerBuilder));
 		builder->entity = self->player;
+		builder->handle = 0;
 		builder->x = 16 * 5;
 		builder->y = 16 * -4;
 		SceneDefer(self, PlayerBuild, builder);

--- a/src/scene.h
+++ b/src/scene.h
@@ -84,9 +84,10 @@ struct Scene
 	RenderTexture2D interfaceLayer;
 	RenderTexture2D transitionLayer;
 	RenderTexture2D debugLayer;
-	InputProfile defaultMenuProfile;
-	InputProfile defaultActionProfile;
-	InputHandler input;
+	InputProfile menuProfiles[MAX_PLAYERS];
+	InputProfile actionProfiles[MAX_PLAYERS];
+	InputHandler inputs[MAX_PLAYERS];
+	Player players[MAX_PLAYERS];
 	bool resetRequested;
 	bool advanceStageRequested;
 	Vector2 actionCameraPosition;
@@ -97,7 +98,6 @@ struct Scene
 	Deque treePositionsFront;
 	// `Deque<SceneDeferParams>`
 	Deque deferred;
-	Player players[MAX_PLAYERS];
 };
 
 void SceneInit(Scene* self);

--- a/src/scene.h
+++ b/src/scene.h
@@ -8,6 +8,7 @@
 #include "input.h"
 #include "level.h"
 
+#define MAX_PLAYERS (4)
 #define MAX_ENTITIES (1024)
 
 #define MAX_SCORE_DIGITS (6 + 1)
@@ -96,6 +97,7 @@ struct Scene
 	Deque treePositionsFront;
 	// `Deque<SceneDeferParams>`
 	Deque deferred;
+	Player players[MAX_PLAYERS];
 };
 
 void SceneInit(Scene* self);


### PR DESCRIPTION
`SceneDefer` gives us direct access to `Scene`; we are no longer forced to just use `Components` to store data. 

We are not going to have `MAX_ENTITIES` `CPlayer`s, so why not save some space and create a smaller array in `Scene` for just a couple of players?